### PR TITLE
Adding support for Laravel newest accessors method

### DIFF
--- a/src/ModelInterface.php
+++ b/src/ModelInterface.php
@@ -275,7 +275,7 @@ class ModelInterface
             $reflection = $this->determineAccessorType($model, $mutator);
             $returnType = (string) $reflection->getReturnType();
 
-            // If Model is using Laravel's new Accessors https://laravel.com/docs/master/eloquent-mutators#defining-an-accessor
+            // If Model is using Laravel's new Accessors
             if ($returnType == 'Illuminate\Database\Eloquent\Casts\Attribute') {
                 // Check to see if the Model has Custom interfaces & has the mutator set with its type
                 if (isset($model->mutations) && isset($model->mutations[$mutator])) {
@@ -283,7 +283,7 @@ class ModelInterface
                     continue;
                 }
                 throw new Exception(
-                    "Model for table {$model->getTable()} is using new mutator: {$mutator}. You must define them inside your models interfaces array"
+                    "Model for table {$model->getTable()} is using new mutator: {$mutator}. You must define them inside your models mutations array"
                 );
             }else {
                 if (isset($model->mutations) && isset($model->mutations[$mutator])) {


### PR DESCRIPTION
In the latest version of Laravel you can now define mutators & accessor within the new `Illuminate\Database\Eloquent\Casts\Attribute`

So for example in `app/Models/Users`
```php
    /**
     * Get the user's first name.
     *
     * @return \Illuminate\Database\Eloquent\Casts\Attribute
     */
    protected function firstName(): Attribute
    {
        return new Attribute(
            get: fn ($value, $attributes) => ucfirst(explode(' ', $attributes['name'])[0]),
        );
    }
```
So I have created a method `determineAccessorType` which will try to find the Mutated Attributes both this new way and the older traditional way.

For this new way at-least you also have to add this to each model to let the model-typer know what to do with it
```php
  public array $mutations = [
      'first_name' => 'string',
  ];
```

For compatibility the old way of
```php
  public function getFirstNameAttribute(): string // <- this
  {
      return explode(' ', $this->name)[0];
  }
```
should work both with and without the new ` $mutations` array 
