### PR TITLE
Use return type of closure

### DIFF
--- a/src/ModelInterface.php
+++ b/src/ModelInterface.php
@@ -296,7 +296,7 @@ class ModelInterface
                     $rf = new ReflectionFunction($closure->get);
                     if ($rf->hasReturnType()) {
                         $returnType = $rf->getReturnType()->getName();
-                        $mutations[$mutator] = $returnType;
+                        $mutations[$mutator] = $this->mappings[$returnType];
                         continue;
                     }else {
                         // warn user to add return type to closure

--- a/src/ModelInterface.php
+++ b/src/ModelInterface.php
@@ -296,7 +296,7 @@ class ModelInterface
                     $rf = new ReflectionFunction($closure->get);
                     if ($rf->hasReturnType()) {
                         $returnType = $rf->getReturnType()->getName();
-                        $mutations[$mutator] = $this->mappings[$returnType];
+                        $mutations[$mutator] = $this->mapReturnType((string) $returnType);
                         continue;
                     }else {
                         // warn user to add return type to closure

--- a/src/ModelInterface.php
+++ b/src/ModelInterface.php
@@ -3,13 +3,12 @@
 
 namespace FumeApp\ModelTyper;
 
-
 use Exception;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Opis\Closure\SerializableClosure;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionFunction;
 use ReflectionException;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Types\Type;
@@ -286,18 +285,23 @@ class ModelInterface
 
             // If Model is using v9 Attributes
             if ($returnType == 'Illuminate\Database\Eloquent\Casts\Attribute') {
-
-                /* TODO: figure out a way to get the returnType from a closure
-                if ($reflection->name === 'isCaptain') {
-                    $closure = $reflection->getClosure($model)->getReturnType();
-                    ray($closure);
-                }
-                */
-
                 // Check to see if the Model has Custom interfaces & has the mutator set with its type
                 if (isset($model->attrs) && isset($model->attrs[$mutator])) {
                     $mutations[$mutator] = $model->attrs[$mutator];
                     continue;
+                }
+                
+                $closure = call_user_func($reflection->getClosure($model), 1);
+                if (! is_null($closure->get)) {
+                    $rf = new ReflectionFunction($closure->get);
+                    if ($rf->hasReturnType()) {
+                        $returnType = $rf->getReturnType()->getName();
+                        $mutations[$mutator] = $returnType;
+                        continue;
+                    }else {
+                        // warn user to add return type to closure
+                        throw new Exception('Unable to determine return type for ' . $mutator . ' Please add a return type to the get closure');
+                    }
                 }
                 throw new Exception(
                     "Model for table {$model->getTable()} is using new mutator: {$mutator}. You must define them inside your models \$attrs array"


### PR DESCRIPTION
If user provides return type of closure we will now try to use that.

```php    
protected function firstName(): Attribute
{
    return new Attribute(
        get: fn (): string => ucfirst(explode(' ', $this->name)[0]),
    );
}
```
I left in the stuff for the `$attrs` on the model, so it will use that stuff first, but I think we can remove and just use this!

