### PR TITLE
Working on Model Enum cast support

### DIFF
--- a/src/ModelInterface.php
+++ b/src/ModelInterface.php
@@ -178,14 +178,17 @@ class ModelInterface
                     $enumVal = "'$value[value]'";
                 }
 
-                // ! This is assuming the @property are in same order as the enum declarations
                 // if comments exists and the key is the same as the value add it before the value
                 if (! empty($values['comments'])) {
-                    if (strpos($values['comments'][$key], $value['name']) === 0) {
-                        $comment = str_replace($value['name'], '', $values['comments'][$key]);
-                        $comment = preg_replace('/[^a-zA-Z0-9\s]/', '', $comment);
-                        $comment = trim($comment);
-                        $code .= "  /** $comment */\n";
+                    // loop over comments and find the comment for this value
+                    foreach ($values['comments'] as $comment) {
+                        if (strpos($comment, $value['name']) === 0) {
+                            $comment = str_replace($value['name'], '', $comment);
+                            $comment = preg_replace('/[^a-zA-Z0-9\s]/', '', $comment);
+                            $comment = trim($comment);
+                            $code .= "  /** $comment */\n";
+                            break;
+                        }
                     }
                 }
 
@@ -198,7 +201,6 @@ class ModelInterface
     }
 
     /**
-     * TODO - Add support for enum comments
      * Extract Enum DocBlock comments
      * @param ReflectionEnum $enum
      * @return array

--- a/src/ModelInterface.php
+++ b/src/ModelInterface.php
@@ -178,10 +178,13 @@ class ModelInterface
                     $enumVal = "'$value[value]'";
                 }
 
+                // ! This is assuming the @property are in same order as the enum declarations
                 // if comments exists and the key is the same as the value add it before the value
                 if (! empty($values['comments'])) {
                     if (strpos($values['comments'][$key], $value['name']) === 0) {
-                        $comment = $values['comments'][$key];
+                        $comment = str_replace($value['name'], '', $values['comments'][$key]);
+                        $comment = preg_replace('/[^a-zA-Z0-9\s]/', '', $comment);
+                        $comment = trim($comment);
                         $code .= "  /** $comment */\n";
                     }
                 }

--- a/src/ModelInterface.php
+++ b/src/ModelInterface.php
@@ -170,7 +170,12 @@ class ModelInterface
         foreach ($casts as $key => $values) {
             $code .= "export enum $key {\n";
             foreach ($values as $value) {
-                $code .= "  $value[name] = $value[value],\n";
+                $enumVal = $value['value'];
+                if (is_string($value['value'])) {
+                    $enumVal = "'$value[value]'";
+                }
+
+                $code .= "  $value[name] = $enumVal,\n";
             }
             $code .= "}\n";
         }


### PR DESCRIPTION
Working on adding in Typescript enum export of model casted attribute. Within Laravel now (along with PHP 8.1) we can cast model attuibrtes as complex enum values. An example is the following where we cast our User model's `role` column into a `UserRoleEnum`


**WIP:** A still nice to have would be allowing us to carry over the comments/docblock comments from the enum into the outputted result. I have some approach using the docblock but still needs more work.

But so far the following works:


> `app/Enums/UserRoleEnum.php` 
```php
<?php

namespace App\Enums;

/**
 * @property Admin - Admin Role
 * @property User - USER Role
 */
enum UserRoleEnum: string
{
    case ADMIN = 'admin';
    case USER = 'user';
}
```
Then inside our User model
> `app/Models/User.php`
```php
protected $casts = [
    'role' => App\Enums\UserRoleEnum::class,
];
```
Now our modeltyper output will look like the following:
```ts
export enum UserRoleEnum {
  ADMIN = 'admin',
  USER = 'user',
}
export interface User {
  // columns
  created_at?: Date
  email: string
  email_verified_at?: Date
  id: number
  name: string
  password: string
  remember_token?: string
  role: UserRoleEnum
  updated_at?: Date
  // mutators
  first_name: string
  last_name: string
}
export type Users = User[]
```
The DocBlock comments need to use the following sytnax
```
@property CASE
```
> `CASE` would map to the enum case name.

You can even order them inside the comment how you want, this would produce the same output
```php
/**
 * @property ADMIN - Admin Role
 * @property SUPER - Super Role
 * @property USER - User Role
 */
enum UserRoleEnum: string
{
    case ADMIN = 'admin';
    case USER = 'user';
    case SUPER = 'super';
}
```

```ts
export enum UserRoleEnum {
  /** Admin Role */
  ADMIN = 'admin',
  /** User Role */
  USER = 'user',
  /** Super Role */
  SUPER = 'super',
}
```






