### PR TITLE
Check if doctrine exists

### DIFF
--- a/src/Commands/ModelTyperCommand.php
+++ b/src/Commands/ModelTyperCommand.php
@@ -58,6 +58,13 @@ class ModelTyperCommand extends Command
             return Command::FAILURE;
         }
 
+        // check if doctrine/dbal is installed
+        if (! class_exists('Doctrine\DBAL\DriverManager')) {
+            $this->error('This package requires doctrine/dbal to be installed.');
+
+            return Command::FAILURE;
+        }
+
         echo $generator($this->option('model'), $this->option('global'), $this->option('json'));
 
         return Command::SUCCESS;


### PR DESCRIPTION
If doctrine is not installed the command will fail and just hang without any indication as to why.
This PR will add a check to see if doctrine is installed.