### PR TITLE
Don't add plurals & api resources by default, rather have them as options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,18 @@ export interface UserMetApiData extends api.MetApiData { data: User }
 export interface UserResponse extends api.MetApiResponse { data: UserMetApiData }
 ```
 
+### Enable all output options
+
+```bash
+artisan model:typer --all
+```
+
+Exports both plurals & api-resources. i.e. it is equivalent to:
+
+```bash
+artisan model:typer --plurals --api-resources
+```
+
 ### Laravel V9 Attribute support
 
 Laravel now has a very different way of specifying [accessors and mutators](https://laravel.com/docs/9.x/eloquent-mutators#accessors-and-mutators).

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ This command will go through all of your models and make [TypeScript Interfaces]
 Starting support is for Laravel v9.21+ and PHP v8.1+
 
 > **Note**
-> This package may require you to install Doctrine DBAL. If so you can run 
+> This package may require you to install Doctrine DBAL. If so you can run
 ```bash
 composer require doctrine/dbal
 ```
@@ -185,6 +185,32 @@ declare global {
       user_id: number
       avatar?: string
 ...
+```
+
+### Output plural interfaces for collections
+
+```bash
+artisan model:typer --plurals
+```
+Exports for example, when a `User` model exists:
+
+```ts
+export type Users = User[]
+```
+
+### Output Api.MetApi* resources
+
+```bash
+artisan model:typer --api-resources
+```
+
+Exports:
+
+```ts
+export interface UserResults extends api.MetApiResults { data: Users }
+export interface UserResult extends api.MetApiResults { data: User }
+export interface UserMetApiData extends api.MetApiData { data: User }
+export interface UserResponse extends api.MetApiResponse { data: UserMetApiData }
 ```
 
 ### Laravel V9 Attribute support

--- a/src/Actions/Generator.php
+++ b/src/Actions/Generator.php
@@ -11,22 +11,18 @@ class Generator
     /**
      * Run the command to generate the output.
      *
-     * @param  string|null  $specificModel
-     * @param  bool  $global
-     * @param  bool  $json
      * @return string
      */
-    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false)
+    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $plurals = false, bool $apiResources = false)
     {
         $models = $this->getModels($specificModel);
 
-        return $this->display($models, $global, $json);
+        return $this->display($models, $global, $json, $plurals, $apiResources);
     }
 
     /**
      * Return collection of models.
      *
-     * @param  string|null  $model
      * @return Collection<int, SplFileInfo>
      */
     protected function getModels(?string $model = null): Collection
@@ -44,11 +40,8 @@ class Generator
      * Display the command output.
      *
      * @param  Collection<int, SplFileInfo>  $models
-     * @param  bool  $global
-     * @param  bool  $json
-     * @return string
      */
-    protected function display(Collection $models, bool $global = false, bool $json = false): string
+    protected function display(Collection $models, bool $global = false, bool $json = false, bool $plurals = false, bool $apiResources = false): string
     {
         if ($models->isEmpty()) {
             return 'ERROR: No models found.';
@@ -58,6 +51,6 @@ class Generator
             return app(GenerateJsonOutput::class)($models);
         }
 
-        return app(GenerateCliOutput::class)($models, $global);
+        return app(GenerateCliOutput::class)($models, $global, $plurals, $apiResources);
     }
 }

--- a/src/Commands/ModelTyperCommand.php
+++ b/src/Commands/ModelTyperCommand.php
@@ -22,7 +22,9 @@ class ModelTyperCommand extends Command
     protected $signature = 'model:typer
                             {--model= : Generate your interfaces for a specific model}
                             {--global : Generate your interfaces in a global namespace named models}
-                            {--json : Output the result as json}';
+                            {--json : Output the result as json}
+                            {--plurals : Output model plurals}
+                            {--api-resources : Output api.MetApi interfaces}';
 
     /**
      * The console command description.
@@ -43,9 +45,6 @@ class ModelTyperCommand extends Command
 
     /**
      * Execute the console command.
-     *
-     * @param  Generator  $generator
-     * @return int
      */
     public function handle(Generator $generator): int
     {
@@ -58,7 +57,7 @@ class ModelTyperCommand extends Command
             return Command::FAILURE;
         }
 
-        echo $generator($this->option('model'), $this->option('global'), $this->option('json'));
+        echo $generator($this->option('model'), $this->option('global'), $this->option('json'), $this->option('plurals'), $this->option('api-resources'));
 
         return Command::SUCCESS;
     }

--- a/src/Commands/ModelTyperCommand.php
+++ b/src/Commands/ModelTyperCommand.php
@@ -24,7 +24,8 @@ class ModelTyperCommand extends Command
                             {--global : Generate your interfaces in a global namespace named models}
                             {--json : Output the result as json}
                             {--plurals : Output model plurals}
-                            {--api-resources : Output api.MetApi interfaces}';
+                            {--api-resources : Output api.MetApi interfaces}
+                            {--all : Enable all output options (equivalent to --plurals --api-resources)}';
 
     /**
      * The console command description.
@@ -57,7 +58,10 @@ class ModelTyperCommand extends Command
             return Command::FAILURE;
         }
 
-        echo $generator($this->option('model'), $this->option('global'), $this->option('json'), $this->option('plurals'), $this->option('api-resources'));
+        $plurals = $this->option('json') || $this->option('all');
+        $apiResources = $this->option('api-resources') || $this->option('all');
+
+        echo $generator($this->option('model'), $this->option('global'), $this->option('json'), $plurals, $apiResources);
 
         return Command::SUCCESS;
     }


### PR DESCRIPTION
Hey team! Hopefully this is kind of self-explanatory.

I'm busy implementing this into a project and it feels like having a few extra things be configurable is handy.