### PR TITLE
Do not include generics in the generated named imports

### DIFF
--- a/src/Actions/GenerateCliOutput.php
+++ b/src/Actions/GenerateCliOutput.php
@@ -123,7 +123,8 @@ class GenerateCliOutput
         collect($this->imports)
             ->unique()
             ->each(function ($import) {
-                $entry = "import { {$import['type']} } from '{$import['import']}'\n";
+                $importTypeWithoutGeneric = Str::before($import['type'], '<');
+                $entry = "import { {$importTypeWithoutGeneric} } from '{$import['import']}'\n";
                 $this->output = $entry . $this->output;
             });
 


### PR DESCRIPTION
This very simple change should fix fumeapp/modeltyper#22 (support for generics).