### PR TITLE
fix disabled plurals output

### DIFF
--- a/src/Actions/GenerateCliOutput.php
+++ b/src/Actions/GenerateCliOutput.php
@@ -91,8 +91,8 @@ class GenerateCliOutput
 
             if ($relations->isNotEmpty() && !$noRelations) {
                 $entry .= "{$this->indent}  // relations\n";
-                $relations->each(function ($rel) use (&$entry, $relationWriter, $optionalRelations) {
-                    $entry .= $relationWriter(relation: $rel, indent: $this->indent,  optionalRelation: $optionalRelations);
+                $relations->each(function ($rel) use (&$entry, $relationWriter, $optionalRelations, $plurals) {
+                    $entry .= $relationWriter(relation: $rel, indent: $this->indent, optionalRelation: $optionalRelations, plurals: $plurals);
                 });
             }
 

--- a/src/Actions/WriteRelationship.php
+++ b/src/Actions/WriteRelationship.php
@@ -17,14 +17,14 @@ class WriteRelationship
      * @param  bool  $jsonOutput
      * @return array|string
      */
-    public function __invoke(array $relation, string $indent = '', bool $jsonOutput = false, bool $optionalRelation = false): array|string
+    public function __invoke(array $relation, string $indent = '', bool $jsonOutput = false, bool $optionalRelation = false, bool $plurals = false): array|string
     {
         $name = Str::snake($relation['name']);
         $relatedModel = $this->getClassName($relation['related']);
         $optional = $optionalRelation ? '?' : '';
 
         $relationType = match ($relation['type']) {
-            'BelongsToMany', 'HasMany', 'HasManyThrough', 'MorphToMany', 'MorphMany', 'MorphedByMany' => Str::plural($relatedModel),
+            'BelongsToMany', 'HasMany', 'HasManyThrough', 'MorphToMany', 'MorphMany', 'MorphedByMany' => $plurals === true ? Str::plural($relatedModel) : (Str::singular($relatedModel) . '[]'),
             'BelongsTo', 'HasOne', 'HasOneThrough', 'MorphOne', 'MorphTo' => Str::singular($relatedModel),
             default => $relatedModel,
         };


### PR DESCRIPTION
this fixes #37

If plurals is disabled, the relation type will output `relations: Relation[]` and if enabled it will output `relations: Relations` and generate an export of  `export type Relations = Relation[]`