### PR TITLE
Feature: generate fillables

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,11 +87,20 @@ public function getFirstNameAttribute(): string // <- this
 ### Additional Options
 
 ```
+--model= : Generate typescript interfaces for a specific model
+--global : Generate typescript interfaces in a global namespace named models
+--json : Output the result as json
+--plurals : Output model plurals
 --no-relations : Do not include relations
 --optional-relations : Make relations optional fields on the model type
 --no-hidden : Do not include hidden model attributes
 --timestamps-date : Output timestamps as a Date object type
 --optional-nullables : Output nullable attributes as optional fields
+--api-resources : Output api.MetApi interfaces
+--resolve-abstract : Attempt to resolve abstract models)
+--fillables : Output model fillables
+--fillable-suffix=fillable
+--all : Enable all output options (equivalent to --plurals --api-resources)'
 ```
 
 ### Custom Interfaces

--- a/src/Actions/GenerateCliOutput.php
+++ b/src/Actions/GenerateCliOutput.php
@@ -33,7 +33,7 @@ class GenerateCliOutput
      *
      * @param  Collection<int, SplFileInfo>  $models
      */
-    public function __invoke(Collection $models, bool $global = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $resolveAbstract = false): string
+    public function __invoke(Collection $models, bool $global = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $resolveAbstract = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
     {
         $modelBuilder = app(BuildModelDetails::class);
         $colAttrWriter = app(WriteColumnAttribute::class);
@@ -44,7 +44,7 @@ class GenerateCliOutput
             $this->indent = '    ';
         }
 
-        $models->each(function (SplFileInfo $model) use ($modelBuilder, $colAttrWriter, $relationWriter, $plurals, $apiResources, $optionalRelations, $noRelations, $noHidden, $timestampsDate, $optionalNullables, $resolveAbstract) {
+        $models->each(function (SplFileInfo $model) use ($modelBuilder, $colAttrWriter, $relationWriter, $plurals, $apiResources, $optionalRelations, $noRelations, $noHidden, $timestampsDate, $optionalNullables, $resolveAbstract, $fillables, $fillableSuffix) {
             $entry = '';
             $modelDetails = $modelBuilder($model, $resolveAbstract);
 
@@ -123,6 +123,12 @@ class GenerateCliOutput
                 $entry .= "{$this->indent}export interface {$name}Result extends api.MetApiResults { data: $name }\n";
                 $entry .= "{$this->indent}export interface {$name}MetApiData extends api.MetApiData { data: $name }\n";
                 $entry .= "{$this->indent}export interface {$name}Response extends api.MetApiResponse { data: {$name}MetApiData }\n";
+            }
+
+            if($fillables) {
+                $fillableAttributes = $reflectionModel->newInstanceWithoutConstructor()->getFillable();
+                $fillablesUnion = implode('|', array_map(fn($fillableAttribute) => "'$fillableAttribute'" ,$fillableAttributes));
+                $entry .= "{$this->indent}export type {$name}{$fillableSuffix} = Pick<$name, $fillablesUnion>\n";
             }
 
             $entry .= "\n";

--- a/src/Actions/Generator.php
+++ b/src/Actions/Generator.php
@@ -13,7 +13,7 @@ class Generator
      *
      * @return string
      */
-    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $resolveAbstract = false)
+    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $resolveAbstract = false, bool $fillables = false, string $fillableSuffix = 'Fillable')
     {
         $models = app(GetModels::class)($specificModel);
 
@@ -33,7 +33,9 @@ class Generator
             $noHidden,
             $timestampsDate,
             $optionalNullables,
-            $resolveAbstract
+            $resolveAbstract,
+            $fillables,
+            $fillableSuffix
         );
     }
 
@@ -42,7 +44,7 @@ class Generator
      *
      * @param  Collection<int, SplFileInfo>  $models
      */
-    protected function display(Collection $models, bool $global = false, bool $json = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $resolveAbstract = false): string
+    protected function display(Collection $models, bool $global = false, bool $json = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $resolveAbstract = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
     {
         if ($json) {
             return app(GenerateJsonOutput::class)($models, $resolveAbstract);
@@ -58,7 +60,9 @@ class Generator
             $noHidden,
             $timestampsDate,
             $optionalNullables,
-            $resolveAbstract
+            $resolveAbstract,
+            $fillables,
+            $fillableSuffix
         );
     }
 }

--- a/src/Commands/ModelTyperCommand.php
+++ b/src/Commands/ModelTyperCommand.php
@@ -32,6 +32,8 @@ class ModelTyperCommand extends Command
                             {--optional-nullables : Output nullable attributes as optional fields}
                             {--api-resources : Output api.MetApi interfaces}
                             {--resolve-abstract : Attempt to resolve abstract models)}
+                            {--fillables : Output model fillables}
+                            {--fillable-suffix=fillable}
                             {--all : Enable all output options (equivalent to --plurals --api-resources)}';
 
     /**
@@ -68,7 +70,9 @@ class ModelTyperCommand extends Command
                 $this->option('no-hidden'),
                 $this->option('timestamps-date'),
                 $this->option('optional-nullables'),
-                $this->option('resolve-abstract')
+                $this->option('resolve-abstract'),
+                $this->option('fillables'),
+                $this->option('fillable-suffix')
             ));
         } catch (ModelTyperException $exception) {
             $this->error($exception->getMessage());

--- a/test/Tests/Feature/Console/ModelTyperCommandTest.php
+++ b/test/Tests/Feature/Console/ModelTyperCommandTest.php
@@ -42,4 +42,16 @@ class ModelTyperCommandTest extends TestCase
         $expected = $this->getExpectedContent('example.ts');
         $this->artisan(ModelTyperCommand::class, ['--model' => User::class])->expectsOutput($expected);
     }
+
+    public function testCommandGeneratesFillablesWhenFillableOptionIsEnabled()
+    {
+        $expected = $this->getExpectedContent('user-fillables.ts');
+        $options = [
+            '--model' => User::class,
+            '--fillables' => true,
+            '--fillable-suffix' => 'Editable'
+        ];
+
+        $this->artisan(ModelTyperCommand::class, $options)->expectsOutput($expected);
+    }
 }

--- a/test/input/expectations/user-fillables.ts
+++ b/test/input/expectations/user-fillables.ts
@@ -1,0 +1,17 @@
+export interface User {
+  // mutators
+  role_traditional: string
+  role_new: string
+  role_enum: Roles
+  role_enum_traditional: Roles
+}
+export type UserEditable = Pick<User, 'role_traditional'|'role_new'>
+
+const Roles = {
+  /** Can do anything */
+  ADMIN: 'admin',
+  /** Standard readonly */
+  USER: 'user',
+} as const;
+
+export type Roles = typeof Roles[keyof typeof Roles]

--- a/test/laravel-skeleton/app/Models/User.php
+++ b/test/laravel-skeleton/app/Models/User.php
@@ -8,6 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
+    protected $fillable = [
+        'role_traditional',
+        'role_new'
+    ];
+
     protected $casts = [
         'role' => Roles::class,
     ];


### PR DESCRIPTION
Add an option to generate types based on model's fillables. This is useful for typing editable versions of models when you are for example creating a new model and want to describe the type that contains the editable attributes of the model.

Also updated command options section of readme to include all options from the command signature.

Add two options:
- --fillables
- --fillable-suffix

Example model:
```php
class Model extends Model
{
    protected $fillable = ['name', 'type'];
}
```
Example command:
`php artisan model:typer --fillables --fillable-suffix=Editable`

Example output:
```ts
export interface Model {
    name: string
    type: string
}
export type ModelEditable = Pick<Model, 'name'|'type'>
```

