### PR TITLE
Fix: incorrect logic in PR #75 merge

### DIFF
--- a/src/Actions/BuildModelDetails.php
+++ b/src/Actions/BuildModelDetails.php
@@ -103,17 +103,16 @@ class BuildModelDetails
 
     private function overrideCollectionWithInterfaces(Collection $columns, Collection $interfaces): Collection
     {
-        return $columns->map(function ($column) use ($interfaces) {
-            $interfaces->each(function ($interface, $key) use (&$column, $interfaces) {
-                if ($key === $column['name']) {
-                    $column['type'] = $interface['type'];
-                    $column['forceType'] = true;
+        return $columns->filter(function ($column) use ($interfaces) {
+            $includeColumn = true;
 
-                    $interfaces->forget($key);
+            $interfaces->each(function ($interface, $key) use ($column, &$includeColumn) {
+                if ($key === $column['name']) {
+                    $includeColumn = false;
                 }
             });
 
-            return $column;
+            return $includeColumn;
         });
     }
 }


### PR DESCRIPTION
Sorry about the incorrect logic on the previous PR #75. The logic has now been corrected so that the columns, mutators, and relationships will be properly overridden by custom interfaces.

In previous PR #75, if matched is found in columns, mutators or relationships, the **`custom interfaces collection`** will be copied and will forget its own item rather than forgetting the matched column, mutator, or relationship. In this update, the **`custom interfaces collection`** will not forget its own item so it will properly provide a typescript output with comment `// overrides` 

Example:

```php
<?php
class Form extends Model
{
    use HasFactory;

    /**
     * The attributes that should be cast.
     *
     * @var array<string, string>
     */
    protected $casts = [
        'id' => 'integer',
        'note' => 'string',
        'is_approved' => 'boolean',
        'is_declined' => 'boolean',
    ];

    /**
     * Custom interfaces for  model typer (fume/modeltyper).
     */
    public array $interfaces = [
        'status' => [
            'type' => "'approved' | 'declined' | 'pending'",
        ],
    ];

    /**
     * The accessors to append to the model's array form.
     *
     * @var array
     */
    protected $appends = [
        'status',
    ];

    /**
     * Get the status of the request.
     */
    protected function status(): Attribute
    {
        return new Attribute(
            get: function () {
                if ($this->is_approved) {
                    return 'approved';
                }

                if ($this->is_declined) {
                    return 'declined';
                }

                return 'pending';
            },
        );
    }
}
```

Before: 
![before](https://github.com/fumeapp/modeltyper/assets/46478426/f0bfaaa8-0a73-4327-85cb-f10314232353)

After:
![after](https://github.com/fumeapp/modeltyper/assets/46478426/2e84f086-ea95-4763-a859-93bc85a553ec)
