### PR TITLE
Feat: additional --use-enums flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ public function getFirstNameAttribute(): string // <- this
 --model= : Generate typescript interfaces for a specific model
 --global : Generate typescript interfaces in a global namespace named models
 --json : Output the result as json
+--use-enums : Use typescript enums instead of object literals
 --plurals : Output model plurals
 --no-relations : Do not include relations
 --optional-relations : Make relations optional fields on the model type
@@ -378,6 +379,6 @@ export interface User {
 }
 ```
 
-> ModelTyper uses Object Literals instead of TS Enums [for opinionated reasons](https://maxheiber.medium.com/alternatives-to-typescript-enums-50e4c16600b1)
+> ModelTyper uses Object Literals by default instead of TS Enums [for opinionated reasons](https://maxheiber.medium.com/alternatives-to-typescript-enums-50e4c16600b1). But you can use `--use-enums` option to use TS Enums instead of Object Literals.
 
 > Notice how the comments are found and parsed - they must follow the specified format

--- a/src/Actions/Generator.php
+++ b/src/Actions/Generator.php
@@ -49,7 +49,7 @@ class Generator
         $mappings = app(GetMappings::class)(setTimestampsToDate: $timestampsDate);
 
         if ($json) {
-            return app(GenerateJsonOutput::class)(models: $models, mappings: $mappings, resolveAbstract: $resolveAbstract);
+            return app(GenerateJsonOutput::class)(models: $models, mappings: $mappings, resolveAbstract: $resolveAbstract, useEnums: $useEnums);
         }
 
         return app(GenerateCliOutput::class)(

--- a/src/Actions/Generator.php
+++ b/src/Actions/Generator.php
@@ -12,7 +12,7 @@ class Generator
      *
      * @return string
      */
-    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $resolveAbstract = false, bool $fillables = false, string $fillableSuffix = 'Fillable')
+    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $resolveAbstract = false, bool $fillables = false, string $fillableSuffix = 'Fillable')
     {
         $models = app(GetModels::class)($specificModel);
 
@@ -33,6 +33,7 @@ class Generator
             timestampsDate: $timestampsDate,
             optionalNullables: $optionalNullables,
             resolveAbstract: $resolveAbstract,
+            useEnums: $useEnums,
             fillables: $fillables,
             fillableSuffix: $fillableSuffix
         );
@@ -43,7 +44,7 @@ class Generator
      *
      * @param  Collection<int, \Symfony\Component\Finder\SplFileInfo>  $models
      */
-    protected function display(Collection $models, bool $global = false, bool $json = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $resolveAbstract = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
+    protected function display(Collection $models, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $resolveAbstract = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
     {
         $mappings = app(GetMappings::class)(setTimestampsToDate: $timestampsDate);
 
@@ -55,6 +56,7 @@ class Generator
             models: $models,
             mappings: $mappings,
             global: $global,
+            useEnums: $useEnums,
             plurals: $plurals,
             apiResources: $apiResources,
             optionalRelations: $optionalRelations,

--- a/src/Actions/WriteColumnAttribute.php
+++ b/src/Actions/WriteColumnAttribute.php
@@ -20,7 +20,7 @@ class WriteColumnAttribute
      * @param  array<string, string>  $mappings
      * @return array{array{name: string, type: string}, ReflectionClass|null}|array{string, ReflectionClass|null}|array{null, null}
      */
-    public function __invoke(ReflectionClass $reflectionModel, array $attribute, array $mappings, string $indent = '', bool $jsonOutput = false, bool $noHidden = false, bool $optionalNullables = false): array
+    public function __invoke(ReflectionClass $reflectionModel, array $attribute, array $mappings, string $indent = '', bool $jsonOutput = false, bool $noHidden = false, bool $optionalNullables = false, bool $useEnums = false): array
     {
         $enumRef = null;
         $returnType = app(MapReturnType::class);
@@ -98,6 +98,10 @@ class WriteColumnAttribute
             }
         }
 
+        if ($useEnums) {
+            $type = $enumRef && $type ? ($type . 'Enum') : $type;
+        }
+
         if ($attribute['nullable']) {
             $type .= '|null';
         }
@@ -139,7 +143,7 @@ class WriteColumnAttribute
     private function ensurePropertyIsValid(string $identifier): string
     {
         $firstCharacter = substr($identifier, 0, 1);
-        
+
         if (! ctype_digit($identifier) && ctype_digit($firstCharacter)) {
             return "'$identifier'";
         }

--- a/src/Commands/ModelTyperCommand.php
+++ b/src/Commands/ModelTyperCommand.php
@@ -26,6 +26,7 @@ class ModelTyperCommand extends Command
                             {--model= : Generate typescript interfaces for a specific model}
                             {--global : Generate typescript interfaces in a global namespace named models}
                             {--json : Output the result as json}
+                            {--use-enums : Use typescript enums instead of object literals}
                             {--plurals : Output model plurals}
                             {--no-relations : Do not include relations}
                             {--optional-relations : Make relations optional fields on the model type}
@@ -65,6 +66,7 @@ class ModelTyperCommand extends Command
                 $this->option('model'),
                 $this->option('global'),
                 $this->option('json'),
+                $this->option('use-enums'),
                 $this->option('plurals') || $this->option('all'),
                 $this->option('api-resources') || $this->option('all'),
                 $this->option('optional-relations'),


### PR DESCRIPTION
Changes:
- Added `--use-enums` flag to the command-line options. This option will use typescript enums instead of object literals.
- It also fixes an error where, when using the object literals, typescript returns an error: `A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference`

Related Issues:
- #54 

Before:
![before](https://github.com/fumeapp/modeltyper/assets/46478426/c0a2acac-5345-4cef-919b-879d1608589c)

After:
![after](https://github.com/fumeapp/modeltyper/assets/46478426/7fe138d5-b648-412e-9e0c-f58c6483f37f)
