### PR TITLE
Add base model extension capability

### DIFF
--- a/config/modeltyper.php
+++ b/config/modeltyper.php
@@ -63,6 +63,42 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Extend Generated Interfaces
+    |--------------------------------------------------------------------------
+    |
+    | Specifies whether to extend the generated TypeScript interfaces with a
+    | custom base interface. This is useful for adding common properties or
+    | methods to all model interfaces.
+    */
+    'extend-interface' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Base Interface Name
+    |--------------------------------------------------------------------------
+    |
+    | Defines the name of the base interface that generated TypeScript interfaces
+    | will extend. This should be an interface that exists in your TypeScript 
+    | codebase.
+    |
+    | Requires extend-interface set to true
+    */
+    'base-interface' => 'BaseModel',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Base Model Import Path
+    |--------------------------------------------------------------------------
+    |
+    | Defines the import path for the base interface that generated TypeScript
+    | interfaces will extend. This allows proper TypeScript imports to be generated.
+    |
+    | Requires extend-interface set to true
+    */
+    'base-model-import-path' => '@/types',
+
+    /*
+    |--------------------------------------------------------------------------
     | Output the Result in JSON Format
     |--------------------------------------------------------------------------
     |

--- a/src/Actions/Generator.php
+++ b/src/Actions/Generator.php
@@ -15,7 +15,7 @@ class Generator
      *
      * @return string
      */
-    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable')
+    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable', bool $extendInterface = false, string $baseInterface = 'BaseModel', string $baseModelImportPath = '@/types')
     {
         $models = app(GetModels::class)($specificModel);
 
@@ -36,7 +36,10 @@ class Generator
             optionalNullables: $optionalNullables,
             useEnums: $useEnums,
             fillables: $fillables,
-            fillableSuffix: $fillableSuffix
+            fillableSuffix: $fillableSuffix,
+            extendInterface: $extendInterface,
+            baseInterface: $baseInterface,
+            baseModelImportPath: $baseModelImportPath
         );
     }
 
@@ -45,7 +48,7 @@ class Generator
      *
      * @param  Collection<int, \Symfony\Component\Finder\SplFileInfo>  $models
      */
-    protected function display(Collection $models, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
+    protected function display(Collection $models, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable', bool $extendInterface = false, string $baseInterface = 'BaseModel', string $baseModelImportPath = '@/types'): string
     {
         $mappings = app(GetMappings::class)(setTimestampsToDate: $timestampsDate);
 
@@ -65,7 +68,10 @@ class Generator
             noHidden: $noHidden,
             optionalNullables: $optionalNullables,
             fillables: $fillables,
-            fillableSuffix: $fillableSuffix
+            fillableSuffix: $fillableSuffix,
+            extendInterface: $extendInterface,
+            baseInterface: $baseInterface,
+            baseModelImportPath: $baseModelImportPath
         );
     }
 }

--- a/src/Commands/ModelTyperCommand.php
+++ b/src/Commands/ModelTyperCommand.php
@@ -39,6 +39,9 @@ class ModelTyperCommand extends Command
                             {--api-resources : Output api.MetApi interfaces}
                             {--fillables : Output model fillables}
                             {--fillable-suffix= : Appends to fillables}
+                            {--extend-interface : Extend generated interfaces with a base interface}
+                            {--base-interface= : Name of the base interface to extend}
+                            {--base-model-import-path= : Import path for the base interface}
                             {--ignore-config : Ignore options set in config}';
 
     /**
@@ -76,6 +79,9 @@ class ModelTyperCommand extends Command
                 optionalNullables: $this->getConfig('optional-nullables'),
                 fillables: $this->getConfig('fillables'),
                 fillableSuffix: $this->getConfig('fillable-suffix'),
+                extendInterface: $this->getConfig('extend-interface'),
+                baseInterface: $this->getConfig('base-interface'),
+                baseModelImportPath: $this->getConfig('base-model-import-path'),
             );
 
             /** @var string|null $path */

--- a/test/input/expectations/user-extend-interface.ts
+++ b/test/input/expectations/user-extend-interface.ts
@@ -1,0 +1,31 @@
+import { BaseModel } from '@/types/models';
+
+export interface User extends BaseModel {
+  // columns
+  id: number;
+  name: string;
+  email: string;
+  email_verified_at: string | null;
+  password?: string;
+  remember_token?: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  // mutators
+  role_traditional: string;
+  role_new: string;
+  role_enum: Roles;
+  role_enum_traditional: Roles;
+  // relations
+  notifications: DatabaseNotification[];
+}
+
+const Roles = {
+  /** Can do anything */
+  ADMIN: 'admin',
+  /** Standard readonly */
+  USER: 'user',
+  /** Value that needs string escaping */
+  USERCLASS: 'App\\Models\\User',
+} as const;
+
+export type Roles = (typeof Roles)[keyof typeof Roles];


### PR DESCRIPTION
I have the need to extend the generated models with a self-declared `BaseModel`, that will only live in my TypeScript code. I had the idea to add this as a feature in modeltyper. 

The feature should generate the following output for the `User` model when the respective flags are set:

```ts
import { BaseModel } from '@/types/models';

export interface User extends BaseModel {
  // columns
  id: number;
  name: string;
  email: string;
  email_verified_at: string | null;
  password?: string;
  remember_token?: string | null;
  created_at: string | null;
  updated_at: string | null;
  // mutators
  role_traditional: string;
  role_new: string;
  role_enum: Roles;
  role_enum_traditional: Roles;
  // relations
  notifications: DatabaseNotification[];
}

const Roles = {
  /** Can do anything */
  ADMIN: 'admin',
  /** Standard readonly */
  USER: 'user',
  /** Value that needs string escaping */
  USERCLASS: 'App\\Models\\User',
} as const;

export type Roles = (typeof Roles)[keyof typeof Roles];
```

I need some help with the tests here, for some reason the `ModelTyperCommandTest::test_command_can_ignore_config_when_option_is_enabled` test is failing with this output:

```
TypeError: FumeApp\ModelTyper\Commands\ModelTyperCommand::getConfig(): Return value must be of type string|bool, null returned
/Users/enesk/my/modeltyper/src/Commands/ModelTyperCommand.php:116
/Users/enesk/my/modeltyper/src/Commands/ModelTyperCommand.php:83
```

Maybe someone has an idea why this is happening?

TODO

- [ ]  Add tests for the correct output of the base model
- [ ]  Update README with examples for the new capability