### PR TITLE
feat: Add “no-counts” and “optional-counts” options, and add _count fields for countable relations

### DIFF
--- a/config/modeltyper.php
+++ b/config/modeltyper.php
@@ -107,6 +107,28 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Disable Countable Relations
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, this will prevent relations from being marked as countable
+    | (array types) in the TypeScript definitions. This can be useful when you
+    | want to treat all relations as single instances.
+    */
+    'no-counts' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Make Countable Relations Optional
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, this will make countable relations (array types) optional
+    | in the TypeScript definitions. This allows for more flexibility in
+    | handling models that may or may not have related collections.
+    */
+    'optional-counts' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Make Model Relationships Optional
     |--------------------------------------------------------------------------
     |

--- a/src/Actions/GenerateCliOutput.php
+++ b/src/Actions/GenerateCliOutput.php
@@ -35,7 +35,7 @@ class GenerateCliOutput
      * @param  Collection<int, SplFileInfo>  $models
      * @param  array<string, string>  $mappings
      */
-    public function __invoke(Collection $models, array $mappings, bool $global = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
+    public function __invoke(Collection $models, array $mappings, bool $global = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noCounts = false, bool $optionalCounts = false, bool $noHidden = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
     {
         $modelBuilder = app(BuildModelDetails::class);
         $colAttrWriter = app(WriteColumnAttribute::class);
@@ -47,7 +47,7 @@ class GenerateCliOutput
             $this->indent = '    ';
         }
 
-        $models->each(function (SplFileInfo $model) use ($mappings, $modelBuilder, $colAttrWriter, $relationWriter, $plurals, $apiResources, $optionalRelations, $noRelations, $noHidden, $optionalNullables, $fillables, $fillableSuffix, $useEnums) {
+        $models->each(function (SplFileInfo $model) use ($mappings, $modelBuilder, $colAttrWriter, $relationWriter, $plurals, $apiResources, $optionalRelations, $noRelations, $noCounts, $optionalCounts, $noHidden, $optionalNullables, $fillables, $fillableSuffix, $useEnums) {
             $entry = '';
             $modelDetails = $modelBuilder($model);
 
@@ -106,8 +106,8 @@ class GenerateCliOutput
 
             if ($relations->isNotEmpty() && ! $noRelations) {
                 $entry .= "{$this->indent}  // relations" . PHP_EOL;
-                $relations->each(function ($rel) use (&$entry, $relationWriter, $optionalRelations, $plurals) {
-                    $entry .= $relationWriter(relation: $rel, indent: $this->indent, optionalRelation: $optionalRelations, plurals: $plurals);
+                $relations->each(function ($rel) use (&$entry, $relationWriter, $optionalRelations, $noCounts, $optionalCounts, $plurals) {
+                    $entry .= $relationWriter(relation: $rel, indent: $this->indent, optionalRelation: $optionalRelations, noCounts: $noCounts, optionalCounts: $optionalCounts, plurals: $plurals);
                 });
             }
 

--- a/src/Actions/GenerateJsonOutput.php
+++ b/src/Actions/GenerateJsonOutput.php
@@ -29,14 +29,14 @@ class GenerateJsonOutput
      * @param  Collection<int, \Symfony\Component\Finder\SplFileInfo>  $models
      * @param  array<string, string>  $mappings
      */
-    public function __invoke(Collection $models, array $mappings, bool $useEnums = false): string
+    public function __invoke(Collection $models, array $mappings, bool $useEnums = false, bool $noCounts = false, bool $optionalCounts = false): string
     {
         $modelBuilder = app(BuildModelDetails::class);
         $colAttrWriter = app(WriteColumnAttribute::class);
         $relationWriter = app(WriteRelationship::class);
         $enumWriter = app(WriteEnumConst::class);
 
-        $models->each(function (SplFileInfo $model) use ($modelBuilder, $colAttrWriter, $relationWriter, $mappings, $useEnums) {
+        $models->each(function (SplFileInfo $model) use ($modelBuilder, $colAttrWriter, $relationWriter, $mappings, $useEnums, $noCounts, $optionalCounts) {
             $modelDetails = $modelBuilder($model);
 
             if ($modelDetails === null) {
@@ -65,8 +65,8 @@ class GenerateJsonOutput
                     return $property;
                 })->toArray();
 
-            $this->output['relations'] = $relations->map(function ($rel) use ($relationWriter, $name) {
-                $relation = $relationWriter(relation: $rel, jsonOutput: true);
+            $this->output['relations'] = $relations->map(function ($rel) use ($relationWriter, $name, $noCounts, $optionalCounts) {
+                $relation = $relationWriter(relation: $rel, jsonOutput: true, noCounts: $noCounts, optionalCounts: $optionalCounts);
 
                 return [
                     $relation['type'] => [

--- a/src/Actions/Generator.php
+++ b/src/Actions/Generator.php
@@ -15,7 +15,7 @@ class Generator
      *
      * @return string
      */
-    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable')
+    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noCounts = false, bool $optionalCounts = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable')
     {
         $models = app(GetModels::class)($specificModel);
 
@@ -31,6 +31,8 @@ class Generator
             apiResources: $apiResources,
             optionalRelations: $optionalRelations,
             noRelations: $noRelations,
+            noCounts: $noCounts,
+            optionalCounts: $optionalCounts,
             noHidden: $noHidden,
             timestampsDate: $timestampsDate,
             optionalNullables: $optionalNullables,
@@ -45,12 +47,12 @@ class Generator
      *
      * @param  Collection<int, \Symfony\Component\Finder\SplFileInfo>  $models
      */
-    protected function display(Collection $models, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
+    protected function display(Collection $models, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noCounts = false, bool $optionalCounts = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
     {
         $mappings = app(GetMappings::class)(setTimestampsToDate: $timestampsDate);
 
         if ($json) {
-            return app(GenerateJsonOutput::class)(models: $models, mappings: $mappings, useEnums: $useEnums);
+            return app(GenerateJsonOutput::class)(models: $models, mappings: $mappings, useEnums: $useEnums, noCounts: $noCounts, optionalCounts: $optionalCounts);
         }
 
         return app(GenerateCliOutput::class)(
@@ -62,6 +64,8 @@ class Generator
             apiResources: $apiResources,
             optionalRelations: $optionalRelations,
             noRelations: $noRelations,
+            noCounts: $noCounts,
+            optionalCounts: $optionalCounts,
             noHidden: $noHidden,
             optionalNullables: $optionalNullables,
             fillables: $fillables,

--- a/src/Actions/WriteRelationship.php
+++ b/src/Actions/WriteRelationship.php
@@ -3,6 +3,7 @@
 namespace FumeApp\ModelTyper\Actions;
 
 use FumeApp\ModelTyper\Traits\ClassBaseName;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 
@@ -16,35 +17,78 @@ class WriteRelationship
      * @param  array{name: string, type: string, related:string}  $relation
      * @return array{type: string, name: string}|string
      */
-    public function __invoke(array $relation, string $indent = '', bool $jsonOutput = false, bool $optionalRelation = false, bool $plurals = false): array|string
+    public function __invoke(array $relation, string $indent = '', bool $jsonOutput = false, bool $optionalRelation = false, ?bool $noCounts = null, ?bool $optionalCounts = null, bool $plurals = false): array|string
     {
         $case = Config::get('modeltyper.case.relations', 'snake');
-        $name = app(MatchCase::class)($case, $relation['name']);
+        $name = App::make(MatchCase::class)($case, $relation['name']);
 
         $relatedModel = $this->getClassName($relation['related']);
         $optional = $optionalRelation ? '?' : '';
 
-        $relationType = match ($relation['type']) {
-            'BelongsToMany', 'HasMany', 'HasManyThrough', 'MorphToMany', 'MorphMany', 'MorphedByMany' => $plurals === true ? Str::plural($relatedModel) : (Str::singular($relatedModel) . '[]'),
-            'BelongsTo', 'HasOne', 'HasOneThrough', 'MorphOne', 'MorphTo' => Str::singular($relatedModel),
-            default => $relatedModel,
-        };
+        // Use config if not explicitly provided
+        $noCounts = $noCounts ?? Config::get('modeltyper.no-counts', false);
+        $optionalCounts = $optionalCounts ?? Config::get('modeltyper.optional-counts', false);
+
+        // Determine if this is a countable relation
+        $isCountable = in_array($relation['type'], [
+            'BelongsToMany', 'HasMany', 'HasManyThrough',
+            'MorphToMany', 'MorphMany', 'MorphedByMany',
+        ]);
+
+        // Handle no-counts option
+        if ($noCounts && $isCountable) {
+            $relationType = Str::singular($relatedModel);
+            $shouldAddCount = false;
+        } else {
+            $relationType = match ($relation['type']) {
+                'BelongsToMany', 'HasMany', 'HasManyThrough', 'MorphToMany', 'MorphMany', 'MorphedByMany' => $plurals === true ? Str::plural($relatedModel) : (Str::singular($relatedModel) . '[]'),
+                'BelongsTo', 'HasOne', 'HasOneThrough', 'MorphOne', 'MorphTo' => Str::singular($relatedModel),
+                default => $relatedModel,
+            };
+            $shouldAddCount = $isCountable;
+        }
+
+        // Handle optional-counts option
+        if ($optionalCounts && $isCountable && ! $noCounts) {
+            $optional = '?';
+        }
 
         if (in_array($relation['type'], Config::get('modeltyper.custom_relationships.singular', []))) {
             $relationType = Str::singular($relation['type']);
+            $shouldAddCount = false;
         }
 
         if (in_array($relation['type'], Config::get('modeltyper.custom_relationships.plural', []))) {
             $relationType = Str::singular($relation['type']);
+            $shouldAddCount = false;
         }
 
         if ($jsonOutput) {
-            return [
+            $result = [
                 'name' => "{$name}{$optional}",
                 'type' => $relationType,
             ];
+
+            // Add count field for countable relationships
+            if ($shouldAddCount) {
+                $countName = "{$name}_count";
+                $result['count'] = [
+                    'name' => "{$countName}",
+                    'type' => 'number',
+                ];
+            }
+
+            return $result;
         }
 
-        return "{$indent}  {$name}{$optional}: {$relationType}" . PHP_EOL;
+        $output = "{$indent}  {$name}{$optional}: {$relationType}" . PHP_EOL;
+
+        // Add count field for countable relationships
+        if ($shouldAddCount) {
+            $countName = "{$name}_count";
+            $output .= "{$indent}  {$countName}: number" . PHP_EOL;
+        }
+
+        return $output;
     }
 }

--- a/src/Commands/ModelTyperCommand.php
+++ b/src/Commands/ModelTyperCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Config;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 #[AsCommand(name: 'model:typer')]
 class ModelTyperCommand extends Command
@@ -39,7 +40,9 @@ class ModelTyperCommand extends Command
                             {--api-resources : Output api.MetApi interfaces}
                             {--fillables : Output model fillables}
                             {--fillable-suffix= : Appends to fillables}
-                            {--ignore-config : Ignore options set in config}';
+                            {--ignore-config : Ignore options set in config}
+                            {--no-counts : Disable countable relations}
+                            {--optional-counts : Make countable relations optional}';
 
     /**
      * The console command description.
@@ -54,6 +57,28 @@ class ModelTyperCommand extends Command
     public function __construct(protected Filesystem $files)
     {
         parent::__construct();
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate typescript interface for a specific model'],
+            ['output-file', 'o', InputOption::VALUE_OPTIONAL, 'Output file path'],
+            ['global', 'g', InputOption::VALUE_NONE, 'Output global namespace'],
+            ['json', 'j', InputOption::VALUE_NONE, 'Output json format'],
+            ['use-enums', 'e', InputOption::VALUE_NONE, 'Use typescript enums'],
+            ['plurals', 'p', InputOption::VALUE_NONE, 'Output plural form for models'],
+            ['api-resources', 'a', InputOption::VALUE_NONE, 'Output api.MetApi interfaces'],
+            ['optional-relations', 'r', InputOption::VALUE_NONE, 'Make model relationships optional'],
+            ['no-relations', 'R', InputOption::VALUE_NONE, 'Exclude model relationships'],
+            ['no-counts', 'c', InputOption::VALUE_NONE, 'Disable countable relations'],
+            ['optional-counts', 'C', InputOption::VALUE_NONE, 'Make countable relations optional'],
+            ['no-hidden', 'H', InputOption::VALUE_NONE, 'Exclude hidden model attributes'],
+            ['timestamps-date', 't', InputOption::VALUE_NONE, 'Output timestamps as date object types'],
+            ['optional-nullables', 'n', InputOption::VALUE_NONE, 'Make nullable attributes optional'],
+            ['fillables', 'f', InputOption::VALUE_NONE, 'Output fillable model attributes'],
+            ['fillable-suffix', 's', InputOption::VALUE_OPTIONAL, 'Suffix for fillable model attributes', 'fillable'],
+        ];
     }
 
     /**
@@ -71,6 +96,8 @@ class ModelTyperCommand extends Command
                 apiResources: $this->getConfig('api-resources'),
                 optionalRelations: $this->getConfig('optional-relations'),
                 noRelations: $this->getConfig('no-relations'),
+                noCounts: $this->getConfig('no-counts'),
+                optionalCounts: $this->getConfig('optional-counts'),
                 noHidden: $this->getConfig('no-hidden'),
                 timestampsDate: $this->getConfig('timestamps-date'),
                 optionalNullables: $this->getConfig('optional-nullables'),

--- a/test/Tests/Feature/Actions/WriteRelationshipTest.php
+++ b/test/Tests/Feature/Actions/WriteRelationshipTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Actions;
 
 use FumeApp\ModelTyper\Actions\WriteRelationship;
+use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
 
 class WriteRelationshipTest extends TestCase
@@ -34,8 +35,14 @@ class WriteRelationshipTest extends TestCase
         $result = $action(relation: $this->relation, jsonOutput: true);
 
         $this->assertIsArray($result);
-
-        $this->assertEquals(['name' => 'notifications', 'type' => 'DatabaseNotification[]'], $result);
+        $this->assertEquals([
+            'name' => 'notifications',
+            'type' => 'DatabaseNotification[]',
+            'count' => [
+                'name' => 'notifications_count',
+                'type' => 'number',
+            ],
+        ], $result);
     }
 
     public function test_action_can_be_indented()
@@ -59,7 +66,14 @@ class WriteRelationshipTest extends TestCase
         $action = app(WriteRelationship::class);
         $result = $action(relation: $this->relation, optionalRelation: true, jsonOutput: true);
 
-        $this->assertEquals(['name' => 'notifications?', 'type' => 'DatabaseNotification[]'], $result);
+        $this->assertEquals([
+            'name' => 'notifications?',
+            'type' => 'DatabaseNotification[]',
+            'count' => [
+                'name' => 'notifications_count',
+                'type' => 'number',
+            ],
+        ], $result);
     }
 
     public function test_action_can_return_plural_relationships()
@@ -68,5 +82,110 @@ class WriteRelationshipTest extends TestCase
         $result = $action(relation: $this->relation, plurals: true);
 
         $this->assertStringContainsString('notifications: DatabaseNotifications', $result);
+    }
+
+    public function test_action_can_handle_no_counts_option()
+    {
+        Config::set('modeltyper.no-counts', true);
+        $action = app(WriteRelationship::class);
+        $result = $action($this->relation);
+
+        $this->assertStringContainsString('notifications: DatabaseNotification', $result);
+        $this->assertStringNotContainsString('notifications: DatabaseNotification[]', $result);
+    }
+
+    public function test_action_can_handle_optional_counts_option()
+    {
+        Config::set('modeltyper.optional-counts', true);
+        $action = app(WriteRelationship::class);
+        $result = $action($this->relation);
+
+        $this->assertStringContainsString('notifications?: DatabaseNotification[]', $result);
+    }
+
+    public function test_action_prioritizes_no_counts_over_optional_counts()
+    {
+        Config::set('modeltyper.no-counts', true);
+        Config::set('modeltyper.optional-counts', true);
+        $action = app(WriteRelationship::class);
+        $result = $action($this->relation);
+
+        $this->assertStringContainsString('notifications: DatabaseNotification', $result);
+        $this->assertStringNotContainsString('notifications?: DatabaseNotification[]', $result);
+    }
+
+    public function test_action_handles_non_countable_relations_with_no_counts()
+    {
+        Config::set('modeltyper.no-counts', true);
+        $action = app(WriteRelationship::class);
+        $nonCountableRelation = [
+            'name' => 'profile',
+            'type' => 'HasOne',
+            'related' => "App\Models\Profile",
+        ];
+        $result = $action($nonCountableRelation);
+
+        $this->assertStringContainsString('profile: Profile', $result);
+    }
+
+    public function test_action_adds_count_field_for_countable_relations()
+    {
+        $action = app(WriteRelationship::class);
+        $result = $action($this->relation);
+
+        $this->assertStringContainsString('notifications: DatabaseNotification[]', $result);
+        $this->assertStringContainsString('notifications_count: number', $result);
+    }
+
+    public function test_action_adds_count_field_for_countable_relations_in_json_output()
+    {
+        $action = app(WriteRelationship::class);
+        $result = $action(relation: $this->relation, jsonOutput: true);
+
+        $this->assertIsArray($result);
+        $this->assertEquals([
+            'name' => 'notifications',
+            'type' => 'DatabaseNotification[]',
+            'count' => [
+                'name' => 'notifications_count',
+                'type' => 'number',
+            ],
+        ], $result);
+    }
+
+    public function test_action_does_not_add_count_field_for_non_countable_relations()
+    {
+        $action = app(WriteRelationship::class);
+        $nonCountableRelation = [
+            'name' => 'profile',
+            'type' => 'HasOne',
+            'related' => "App\Models\Profile",
+        ];
+        $result = $action($nonCountableRelation);
+
+        $this->assertStringContainsString('profile: Profile', $result);
+        $this->assertStringNotContainsString('profile_count', $result);
+    }
+
+    public function test_action_does_not_add_count_field_when_no_counts_is_enabled()
+    {
+        Config::set('modeltyper.no-counts', true);
+        $action = app(WriteRelationship::class);
+        $result = $action($this->relation);
+
+        $this->assertStringContainsString('notifications: DatabaseNotification', $result);
+        $this->assertStringNotContainsString('notifications_count', $result);
+    }
+
+    public function test_action_optional_counts_makes_count_field_optional()
+    {
+        Config::set('modeltyper.optional-counts', true);
+        $action = app(WriteRelationship::class);
+        $result = $action($this->relation);
+
+        // The main relation should be optional
+        $this->assertStringContainsString('notifications?: DatabaseNotification[]', $result);
+        // The count field should still be required (since counts are always present if relation is loaded)
+        $this->assertStringContainsString('notifications_count: number', $result);
     }
 }


### PR DESCRIPTION
- Added two new config options (and CLI flags) – “no-counts” and “optional-counts” – so that countable relations (like “users”, “flows”) can be output as singular (or optional) in the generated TypeScript interfaces.
- For every countable relation (e.g. “users”, “flows”, “organization_invitations”), a “count” field (e.g. “users_count”, “flows_count”) is now added (unless “no-counts” is enabled).
- Updated tests (and the WriteRelationship class) so that if “noCounts” or “optionalCounts” aren’t passed, the config values are used.
- All tests pass.