### PR TITLE
Add count and exists attributes for relationships in TypeScript models

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+[*.ts]
+indent_size = 2

--- a/config/modeltyper.php
+++ b/config/modeltyper.php
@@ -129,6 +129,46 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Exclude Count Attributes from Relationships
+    |--------------------------------------------------------------------------
+    |
+    | Specifies whether to exclude count-related attributes for relationships
+    | from the TypeScript definitions.
+    */
+    'no-counts' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Make Count Attributes Optional
+    |--------------------------------------------------------------------------
+    |
+    | Specifies whether count-related attributes for relationships should be
+    | marked as optional in the TypeScript definitions.
+    */
+    'optional-counts' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Exclude Exists Attributes
+    |--------------------------------------------------------------------------
+    |
+    | Determines whether to exclude the `exists` property from model TypeScript
+    | definitions.
+    */
+    'no-exists' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Make Exists Attribute Optional
+    |--------------------------------------------------------------------------
+    |
+    | Determines whether the `exists` property should be optional in the
+    | TypeScript definitions.
+    */
+    'optional-exists' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Output Timestamps as Date Object Types
     |--------------------------------------------------------------------------
     |
@@ -222,7 +262,6 @@ return [
         'singular' => [
             // 'belongsToThrough',
         ],
-
         'plural' => [
             //
         ],
@@ -232,10 +271,11 @@ return [
     |--------------------------------------------------------------------------
     | Case for Model Attributes and Relationships
     |--------------------------------------------------------------------------
-    | Options: snake, camel, pascal
+    |
     | Defines the case style for model attributes and relationships in the
-    | TypeScript definitions. For keeping a consistent naming
-    | convention throughout the codebase.
+    | TypeScript definitions. Choose from: snake, camel, or pascal.
+    |
+    | This helps in maintaining consistent naming conventions across the codebase.
     */
     'case' => [
         'columns' => 'snake',
@@ -248,7 +288,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | The include models list allows you to allowlist certain models from being
-    | generated.
+    | generated. Only these models will be considered.
     */
     'included_models' => [
         // Only these models are allowed

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,9 @@
   <a href="https://www.typescriptlang.org/"><img src="https://miro.medium.com/max/816/1*mn6bOs7s6Qbao15PMNRyOA.png" width="92" height="92" /></a>
 </p>
 
-Model Typer is a powerful tool designed for developers working with Laravel and TypeScript. Its primary purpose is to simplify the generation of TypeScript interfaces from Laravel models, enhancing type safety and consistency in your applications.
+Model Typer is a powerful tool designed for developers working with Laravel and TypeScript. Its primary purpose is to
+simplify the generation of TypeScript interfaces from Laravel models, enhancing type safety and consistency in your
+applications.
 
 ## Upgrade Guide
 
@@ -81,9 +83,12 @@ export type Teams = Array<Team>;
 
 ### How does it work?
 
-This command will go through all of your models and make [TypeScript Interfaces](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#interfaces) based on the database columns, mutators, and relationships.
+This command will go through all of your models and
+make [TypeScript Interfaces](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#interfaces) based on the
+database columns, mutators, and relationships.
 
-You can then pipe the output into your preferred `???.d.ts`, or set the [optional argument](#optional-arguments) `output-file` to generate it
+You can then pipe the output into your preferred `???.d.ts`, or set the [optional argument](#optional-arguments)
+`output-file` to generate it
 
 > [!TIP]
 > To view the current mappings that are being used, use the following command:
@@ -96,7 +101,8 @@ You can then pipe the output into your preferred `???.d.ts`, or set the [optiona
 
 ### Requirements
 
-1. You must have a [return type](https://www.php.net/manual/en/language.types.declarations.php) for your model relationships
+1. You must have a [return type](https://www.php.net/manual/en/language.types.declarations.php) for your model
+   relationships
 
 ```php
 public function providers(): HasMany // <- this
@@ -120,7 +126,6 @@ protected function firstName(): Attribute
 
 - output-file : Echo the definitions into a file
 
-
 ### Additional Options
 
 - --model= : Generate typescript interfaces for a specific model
@@ -131,6 +136,10 @@ protected function firstName(): Attribute
 - --no-relations : Do not include relations
 - --optional-relations : Make relations optional fields on the model type
 - --no-hidden : Do not include hidden model attributes
+- --no-counts : Do not include counts for relationships
+- --optional-counts : Make relationship counts optional fields on the model type
+- --no-exists : Do not include exists for relationships
+- --optional-exists : Make relationship exists optional fields on the model type
 - --timestamps-date : Output timestamps as a Date object type
 - --optional-nullables : Output nullable attributes as optional fields
 - --api-resources : Output api.MetApi interfaces
@@ -228,7 +237,6 @@ Then inside `custom_mappings` add the Laravel type as the key and assign the Typ
 
 You can also add mappings for your [Custom Casts](https://laravel.com/docs/11.x/eloquent-mutators#custom-casts)
 
-
 ```php
 'custom_mappings' => [
     'App\Casts\YourCustomCast' => 'string | null',
@@ -265,6 +273,7 @@ declare global {
 ```bash
 artisan model:typer --plurals
 ```
+
 Exports for example, when a `User` model exists:
 
 ```ts
@@ -316,10 +325,13 @@ artisan model:typer --json
 
 ### Enum Eloquent Attribute Casting
 
-Laravel lets you cast [Enums in your models](https://laravel.com/docs/11.x/eloquent-mutators#enum-casting). This will get detected and bring in your enum class with your comments:
+Laravel lets you cast [Enums in your models](https://laravel.com/docs/11.x/eloquent-mutators#enum-casting). This will
+get detected and bring in your enum class with your comments:
 
 > [!NOTE]
-> ModelTyper uses Object Literals by default instead of TS Enums [for opinionated reasons](https://maxheiber.medium.com/alternatives-to-typescript-enums-50e4c16600b1). But you can use `--use-enums` option to use TS Enums instead of Object Literals.
+> ModelTyper uses Object Literals by default instead of TS
+> Enums [for opinionated reasons](https://maxheiber.medium.com/alternatives-to-typescript-enums-50e4c16600b1). But you can
+> use `--use-enums` option to use TS Enums instead of Object Literals.
 
 `app/Enums/UserRoleEnum.php`
 

--- a/src/Actions/GenerateCliOutput.php
+++ b/src/Actions/GenerateCliOutput.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FumeApp\ModelTyper\Actions;
 
 use FumeApp\ModelTyper\Traits\ClassBaseName;
@@ -8,9 +10,10 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use ReflectionException;
 use Symfony\Component\Finder\SplFileInfo;
 
-class GenerateCliOutput
+final class GenerateCliOutput
 {
     use ClassBaseName;
     use ModelRefClass;
@@ -34,8 +37,10 @@ class GenerateCliOutput
      *
      * @param  Collection<int, SplFileInfo>  $models
      * @param  array<string, string>  $mappings
+     *
+     * @throws ReflectionException
      */
-    public function __invoke(Collection $models, array $mappings, bool $global = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
+    public function __invoke(Collection $models, array $mappings, bool $global = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
     {
         $modelBuilder = app(BuildModelDetails::class);
         $colAttrWriter = app(WriteColumnAttribute::class);
@@ -43,11 +48,11 @@ class GenerateCliOutput
 
         if ($global) {
             $namespace = Config::get('modeltyper.global-namespace', 'models');
-            $this->output .= 'export {}' . PHP_EOL . 'declare global {' . PHP_EOL . "  export namespace {$namespace} {" . PHP_EOL . PHP_EOL;
+            $this->output .= 'export {}'.PHP_EOL.'declare global {'.PHP_EOL."  export namespace {$namespace} {".PHP_EOL.PHP_EOL;
             $this->indent = '    ';
         }
 
-        $models->each(function (SplFileInfo $model) use ($mappings, $modelBuilder, $colAttrWriter, $relationWriter, $plurals, $apiResources, $optionalRelations, $noRelations, $noHidden, $optionalNullables, $fillables, $fillableSuffix, $useEnums) {
+        $models->each(function (SplFileInfo $model) use ($mappings, $modelBuilder, $colAttrWriter, $relationWriter, $plurals, $apiResources, $optionalRelations, $noRelations, $noHidden, $noCounts, $optionalCounts, $noExists, $optionalExists, $optionalNullables, $fillables, $fillableSuffix, $useEnums) {
             $entry = '';
             $modelDetails = $modelBuilder(
                 modelFile: $model,
@@ -72,10 +77,10 @@ class GenerateCliOutput
 
             $this->imports = array_merge($this->imports, $imports->toArray());
 
-            $entry .= "{$this->indent}export interface {$name} {" . PHP_EOL;
+            $entry .= "{$this->indent}export interface {$name} {".PHP_EOL;
 
             if ($columns->isNotEmpty()) {
-                $entry .= "{$this->indent}  // columns" . PHP_EOL;
+                $entry .= "{$this->indent}  // columns".PHP_EOL;
                 $columns->each(function ($att) use (&$entry, $reflectionModel, $colAttrWriter, $noHidden, $optionalNullables, $mappings, $useEnums) {
                     [$line, $enum] = $colAttrWriter(reflectionModel: $reflectionModel, attribute: $att, mappings: $mappings, indent: $this->indent, noHidden: $noHidden, optionalNullables: $optionalNullables, useEnums: $useEnums);
                     if (! empty($line)) {
@@ -88,7 +93,7 @@ class GenerateCliOutput
             }
 
             if ($nonColumns->isNotEmpty()) {
-                $entry .= "{$this->indent}  // mutators" . PHP_EOL;
+                $entry .= "{$this->indent}  // mutators".PHP_EOL;
                 $nonColumns->each(function ($att) use (&$entry, $reflectionModel, $colAttrWriter, $noHidden, $optionalNullables, $mappings, $useEnums) {
                     [$line, $enum] = $colAttrWriter(reflectionModel: $reflectionModel, attribute: $att, mappings: $mappings, indent: $this->indent, noHidden: $noHidden, optionalNullables: $optionalNullables, useEnums: $useEnums);
                     if (! empty($line)) {
@@ -101,7 +106,7 @@ class GenerateCliOutput
             }
 
             if ($interfaces->isNotEmpty()) {
-                $entry .= "{$this->indent}  // overrides" . PHP_EOL;
+                $entry .= "{$this->indent}  // overrides".PHP_EOL;
                 $interfaces->each(function ($interface) use (&$entry, $reflectionModel, $colAttrWriter, $mappings) {
                     [$line] = $colAttrWriter(reflectionModel: $reflectionModel, attribute: $interface, mappings: $mappings, indent: $this->indent);
                     $entry .= $line;
@@ -109,33 +114,33 @@ class GenerateCliOutput
             }
 
             if ($relations->isNotEmpty() && ! $noRelations) {
-                $entry .= "{$this->indent}  // relations" . PHP_EOL;
-                $relations->each(function ($rel) use (&$entry, $relationWriter, $optionalRelations, $plurals) {
-                    $entry .= $relationWriter(relation: $rel, indent: $this->indent, optionalRelation: $optionalRelations, plurals: $plurals);
+                $entry .= "{$this->indent}  // relations".PHP_EOL;
+                $relations->each(function ($rel) use (&$entry, $relationWriter, $optionalRelations, $noCounts, $optionalCounts, $noExists, $optionalExists, $plurals) {
+                    $entry .= $relationWriter(relation: $rel, indent: $this->indent, optionalRelation: $optionalRelations, noCounts: $noCounts, optionalCounts: $optionalCounts, noExists: $noExists, optionalExists: $optionalExists, plurals: $plurals);
                 });
             }
 
-            $entry .= "{$this->indent}}" . PHP_EOL;
+            $entry .= "{$this->indent}}".PHP_EOL;
 
             if ($plurals) {
                 $plural = Str::plural($name);
-                $entry .= "{$this->indent}export type $plural = {$name}[]" . PHP_EOL;
+                $entry .= "{$this->indent}export type $plural = {$name}[]".PHP_EOL;
 
                 if ($apiResources) {
-                    $entry .= "{$this->indent}export interface {$name}Results extends api.MetApiResults { data: $plural }" . PHP_EOL;
+                    $entry .= "{$this->indent}export interface {$name}Results extends api.MetApiResults { data: $plural }".PHP_EOL;
                 }
             }
 
             if ($apiResources) {
-                $entry .= "{$this->indent}export interface {$name}Result extends api.MetApiResults { data: $name }" . PHP_EOL;
-                $entry .= "{$this->indent}export interface {$name}MetApiData extends api.MetApiData { data: $name }" . PHP_EOL;
-                $entry .= "{$this->indent}export interface {$name}Response extends api.MetApiResponse { data: {$name}MetApiData }" . PHP_EOL;
+                $entry .= "{$this->indent}export interface {$name}Result extends api.MetApiResults { data: $name }".PHP_EOL;
+                $entry .= "{$this->indent}export interface {$name}MetApiData extends api.MetApiData { data: $name }".PHP_EOL;
+                $entry .= "{$this->indent}export interface {$name}Response extends api.MetApiResponse { data: {$name}MetApiData }".PHP_EOL;
             }
 
             if ($fillables) {
                 $fillableAttributes = $reflectionModel->newInstanceWithoutConstructor()->getFillable();
                 $fillablesUnion = implode(' | ', array_map(fn ($fillableAttribute) => "'$fillableAttribute'", $fillableAttributes));
-                $entry .= "{$this->indent}export type {$name}{$fillableSuffix} = Pick<$name, $fillablesUnion>" . PHP_EOL;
+                $entry .= "{$this->indent}export type {$name}{$fillableSuffix} = Pick<$name, $fillablesUnion>".PHP_EOL;
             }
 
             $entry .= PHP_EOL;
@@ -153,14 +158,14 @@ class GenerateCliOutput
             ->unique()
             ->each(function ($import) {
                 $importTypeWithoutGeneric = Str::before($import['type'], '<');
-                $entry = "import { {$importTypeWithoutGeneric} } from '{$import['import']}'" . PHP_EOL;
-                $this->output = $entry . $this->output;
+                $entry = "import { {$importTypeWithoutGeneric} } from '{$import['import']}'".PHP_EOL;
+                $this->output = $entry.$this->output;
             });
 
         if ($global) {
-            $this->output .= '  }' . PHP_EOL . '}' . PHP_EOL . PHP_EOL;
+            $this->output .= '  }'.PHP_EOL.'}'.PHP_EOL.PHP_EOL;
         }
 
-        return substr($this->output, 0, strrpos($this->output, PHP_EOL));
+        return mb_substr($this->output, 0, mb_strrpos($this->output, PHP_EOL));
     }
 }

--- a/src/Actions/Generator.php
+++ b/src/Actions/Generator.php
@@ -1,22 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FumeApp\ModelTyper\Actions;
 
 use FumeApp\ModelTyper\Exceptions\ModelTyperException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use ReflectionException;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
- * @throws \FumeApp\ModelTyper\Exceptions\ModelTyperException
+ * @throws ModelTyperException
  */
-class Generator
+final class Generator
 {
     /**
      * Run the command to generate the output.
      *
-     * @return string
+     * @throws ModelTyperException
      */
-    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable')
+    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $noCounts = false, bool $optionalCounts = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
     {
         $models = app(GetModels::class)(
             model: $specificModel,
@@ -32,14 +36,16 @@ class Generator
             models: $models,
             global: $global,
             json: $json,
+            useEnums: $useEnums,
             plurals: $plurals,
             apiResources: $apiResources,
             optionalRelations: $optionalRelations,
             noRelations: $noRelations,
             noHidden: $noHidden,
+            noCounts: $noCounts,
+            optionalCounts: $optionalCounts,
             timestampsDate: $timestampsDate,
             optionalNullables: $optionalNullables,
-            useEnums: $useEnums,
             fillables: $fillables,
             fillableSuffix: $fillableSuffix
         );
@@ -48,14 +54,16 @@ class Generator
     /**
      * Return the command output.
      *
-     * @param  Collection<int, \Symfony\Component\Finder\SplFileInfo>  $models
+     * @param  Collection<int, SplFileInfo>  $models
+     *
+     * @throws ReflectionException
      */
-    protected function display(Collection $models, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
+    private function display(Collection $models, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
     {
         $mappings = app(GetMappings::class)(setTimestampsToDate: $timestampsDate);
 
         if ($json) {
-            return app(GenerateJsonOutput::class)(models: $models, mappings: $mappings, useEnums: $useEnums);
+            return app(GenerateJsonOutput::class)(models: $models, mappings: $mappings, useEnums: $useEnums, noCounts: $noCounts, optionalCounts: $optionalCounts, noExists: $noExists, optionalExists: $optionalExists);
         }
 
         return app(GenerateCliOutput::class)(
@@ -68,6 +76,8 @@ class Generator
             optionalRelations: $optionalRelations,
             noRelations: $noRelations,
             noHidden: $noHidden,
+            noCounts: $noCounts,
+            optionalCounts: $optionalCounts,
             optionalNullables: $optionalNullables,
             fillables: $fillables,
             fillableSuffix: $fillableSuffix

--- a/src/Actions/WriteRelationship.php
+++ b/src/Actions/WriteRelationship.php
@@ -16,35 +16,111 @@ class WriteRelationship
      * @param  array{name: string, type: string, related:string}  $relation
      * @return array{type: string, name: string}|string
      */
-    public function __invoke(array $relation, string $indent = '', bool $jsonOutput = false, bool $optionalRelation = false, bool $plurals = false): array|string
+    public function __invoke(array $relation, string $indent = '', bool $jsonOutput = false, bool $optionalRelation = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $plurals = false): array|string
     {
-        $case = Config::get('modeltyper.case.relations', 'snake');
-        $name = app(MatchCase::class)($case, $relation['name']);
+        $relationCase = Config::get('modeltyper.case.relations', 'snake');
+        $columnsCase = Config::get('modeltyper.case.columns', 'snake');
+        $name = app(MatchCase::class)($relationCase, $relation['name']);
 
         $relatedModel = $this->getClassName($relation['related']);
         $optional = $optionalRelation ? '?' : '';
 
-        $relationType = match ($relation['type']) {
-            'BelongsToMany', 'HasMany', 'HasManyThrough', 'MorphToMany', 'MorphMany', 'MorphedByMany' => $plurals === true ? Str::plural($relatedModel) : (Str::singular($relatedModel) . '[]'),
-            'BelongsTo', 'HasOne', 'HasOneThrough', 'MorphOne', 'MorphTo' => Str::singular($relatedModel),
-            default => $relatedModel,
-        };
+        // Use config if not explicitly provided
+        $noCounts = $noCounts ?? Config::get('modeltyper.no-counts', false);
+        $optionalCounts = $optionalCounts ?? Config::get('modeltyper.optional-counts', false);
+        $noExists = $noExists ?? Config::get('modeltyper.no-exists', false);
+        $optionalExists = $optionalExists ?? Config::get('modeltyper.optional-exists', false);
+
+        // Determine if this is a countable relation
+        $isCountable = in_array($relation['type'], [
+            'BelongsToMany', 'HasMany', 'HasManyThrough',
+            'MorphToMany', 'MorphMany', 'MorphedByMany',
+        ]);
+
+        // Handle no-counts option
+        if ($noCounts && $isCountable) {
+            $relationType = Str::singular($relatedModel);
+            $shouldAddCount = false;
+        } else {
+            $relationType = match ($relation['type']) {
+                'BelongsToMany', 'HasMany', 'HasManyThrough', 'MorphToMany', 'MorphMany', 'MorphedByMany' => $plurals === true ? Str::plural($relatedModel) : (Str::singular($relatedModel) . '[]'),
+                'BelongsTo', 'HasOne', 'HasOneThrough', 'MorphOne', 'MorphTo' => Str::singular($relatedModel),
+                default => $relatedModel,
+            };
+            $shouldAddCount = $isCountable;
+        }
+
+        // Handle optional-counts option
+        if ($optionalCounts && $isCountable && ! $noCounts) {
+            $optional = '?';
+        }
 
         if (in_array($relation['type'], Config::get('modeltyper.custom_relationships.singular', []))) {
             $relationType = Str::singular($relation['type']);
+            $shouldAddCount = false;
         }
 
         if (in_array($relation['type'], Config::get('modeltyper.custom_relationships.plural', []))) {
             $relationType = Str::singular($relation['type']);
+            $shouldAddCount = false;
         }
 
+        $countName = match ($columnsCase) {
+            'camel' => Str::camel("{$name}Count"),
+            'pascal' => Str::studly("{$name}Count"),
+            'kebab' => Str::kebab("{$name}-count"),
+            default => "{$name}_count",
+        };
+
+        $existsName = match ($columnsCase) {
+            'camel' => Str::camel("{$name}Exists"),
+            'pascal' => Str::studly("{$name}Exists"),
+            'kebab' => Str::kebab("{$name}-exists"),
+            default => "{$name}_exists",
+        };
+
+        // Determine if we should add exists field
+        $shouldAddExists = ! $noExists && $isCountable;
+        $optionalCounts = $optionalCounts ? '?' : '';
+        $existsOptional = $optionalExists ? '?' : '';
+
         if ($jsonOutput) {
-            return [
+            $result = [
                 'name' => "{$name}{$optional}",
                 'type' => $relationType,
             ];
+
+            // Add count field for countable relationships
+            if ($shouldAddCount) {
+                $result['count'] = [
+                    'name' => "{$countName}{$optionalCounts}",
+                    'type' => 'number',
+                ];
+            }
+
+            // Add exists field for countable relationships
+            if ($shouldAddExists) {
+                $result['exists'] = [
+                    'name' => "{$existsName}{$existsOptional}",
+                    'type' => 'boolean',
+                ];
+            }
+
+            return $result;
         }
 
-        return "{$indent}  {$name}{$optional}: {$relationType}" . PHP_EOL;
+        $output = "{$indent}  {$name}{$optional}: {$relationType}" . PHP_EOL;
+
+        // Add count field for countable relationships
+        if ($shouldAddCount) {
+            $output .= "{$indent}  {$countName}{$optionalCounts}: number" . PHP_EOL;
+        }
+
+        // Add exists field for countable relationships
+        if ($shouldAddExists) {
+            $output .= "{$indent}  {$existsName}{$existsOptional}: boolean" . PHP_EOL;
+        }
+
+        return $output;
     }
 }

--- a/src/Commands/ModelTyperCommand.php
+++ b/src/Commands/ModelTyperCommand.php
@@ -34,6 +34,8 @@ class ModelTyperCommand extends Command
                             {--no-relations : Do not include relations}
                             {--optional-relations : Make relations optional fields on the model type}
                             {--no-hidden : Do not include hidden model attributes}
+                            {--no-counts : Do not include counts on relations}
+                            {--optional-counts : Make counts on relations optional fields}
                             {--timestamps-date : Output timestamps as a Date object type}
                             {--optional-nullables : Output nullable attributes as optional fields}
                             {--api-resources : Output api.MetApi interfaces}
@@ -72,6 +74,8 @@ class ModelTyperCommand extends Command
                 optionalRelations: $this->getConfig('optional-relations'),
                 noRelations: $this->getConfig('no-relations'),
                 noHidden: $this->getConfig('no-hidden'),
+                noCounts: $this->getConfig('no-counts'),
+                optionalCounts: $this->getConfig('optional-counts'),
                 timestampsDate: $this->getConfig('timestamps-date'),
                 optionalNullables: $this->getConfig('optional-nullables'),
                 fillables: $this->getConfig('fillables'),

--- a/test/Tests/Feature/Actions/WriteRelationshipTest.php
+++ b/test/Tests/Feature/Actions/WriteRelationshipTest.php
@@ -35,7 +35,7 @@ class WriteRelationshipTest extends TestCase
 
         $this->assertIsArray($result);
 
-        $this->assertEquals(['name' => 'notifications', 'type' => 'DatabaseNotification[]'], $result);
+        $this->assertEquals(['name' => 'notifications', 'type' => 'DatabaseNotification[]', 'count' => ['name' => 'notifications_count', 'type' => 'number', ], 'exists' => ['name' => 'notifications_exists', 'type' => 'boolean']], $result);
     }
 
     public function test_action_can_be_indented()
@@ -59,8 +59,18 @@ class WriteRelationshipTest extends TestCase
         $action = app(WriteRelationship::class);
         $result = $action(relation: $this->relation, optionalRelation: true, jsonOutput: true);
 
-        $this->assertEquals(['name' => 'notifications?', 'type' => 'DatabaseNotification[]'], $result);
-    }
+        $this->assertEquals([
+            'name' => 'notifications?',
+            'type' => 'DatabaseNotification[]',
+            'count' => [
+                'name' => 'notifications_count',
+                'type' => 'number',
+            ],
+            'exists' => [
+                'name' => 'notifications_exists',
+                'type' => 'boolean',
+            ],
+        ], $result);    }
 
     public function test_action_can_return_plural_relationships()
     {
@@ -68,5 +78,66 @@ class WriteRelationshipTest extends TestCase
         $result = $action(relation: $this->relation, plurals: true);
 
         $this->assertStringContainsString('notifications: DatabaseNotifications', $result);
+    }
+
+    // Add newly added count and exists tests
+    public function test_action_can_return_count_relationships()
+    {
+        $action = app(WriteRelationship::class);
+        $result = $action(relation: $this->relation);
+
+        $this->assertStringContainsString('notifications_count: number', $result);
+    }
+
+    public function test_action_can_return_exists_relationships()
+    {
+        $action = app(WriteRelationship::class);
+        $result = $action(relation: $this->relation);
+
+        $this->assertStringContainsString('notifications_exists: boolean', $result);
+    }
+
+    public function test_action_can_return_optional_count_relationships()
+    {
+        $action = app(WriteRelationship::class);
+        $result = $action(relation: $this->relation, optionalCounts: true);
+
+        $this->assertStringContainsString('notifications_count?: number', $result);
+    }
+
+    public function test_action_can_return_optional_exists_relationships()
+    {
+        $action = app(WriteRelationship::class);
+        $result = $action(relation: $this->relation, optionalExists: true);
+
+        $this->assertStringContainsString('notifications_exists?: boolean', $result);
+    }
+
+    public function test_action_can_return_optional_count_and_exists_relationships()
+    {
+        $action = app(WriteRelationship::class);
+        $result = $action(relation: $this->relation, optionalCounts: true, optionalExists: true);
+
+        $this->assertStringContainsString('notifications_count?: number', $result);
+        $this->assertStringContainsString('notifications_exists?: boolean', $result);
+    }
+
+    public function test_action_can_return_optional_count_and_exists_relationships_as_array()
+    {
+        $action = app(WriteRelationship::class);
+        $result = $action(relation: $this->relation, optionalCounts: true, optionalExists: true, jsonOutput: true);
+
+        $this->assertEquals([
+            'name' => 'notifications?',
+            'type' => 'DatabaseNotification[]',
+            'count' => [
+                'name' => 'notifications_count?',
+                'type' => 'number',
+            ],
+            'exists' => [
+                'name' => 'notifications_exists?',
+                'type' => 'boolean',
+            ],
+        ], $result);
     }
 }

--- a/test/input/expectations/complex-model-camel-case.ts
+++ b/test/input/expectations/complex-model-camel-case.ts
@@ -36,4 +36,6 @@ export interface Complex {
   deletedAt: string | null
   // relations
   complexRelationships: ComplexRelationship[]
+  complexRelationshipsCount: number
+  complexRelationshipsExists: boolean
 }

--- a/test/input/expectations/complex-model-pascal-case.ts
+++ b/test/input/expectations/complex-model-pascal-case.ts
@@ -36,4 +36,6 @@ export interface Complex {
   DeletedAt: string | null
   // relations
   ComplexRelationships: ComplexRelationship[]
+  ComplexRelationshipsCount: number
+  ComplexRelationshipsExists: boolean
 }

--- a/test/input/expectations/complex-model-with-cast.ts
+++ b/test/input/expectations/complex-model-with-cast.ts
@@ -36,4 +36,6 @@ export interface Complex {
   deleted_at: string | null
   // relations
   complex_relationships: ComplexRelationship[]
+  complex_relationships_count: number
+  complex_relationships_exists: boolean
 }

--- a/test/input/expectations/complex-model.ts
+++ b/test/input/expectations/complex-model.ts
@@ -36,4 +36,6 @@ export interface Complex {
   deleted_at: string | null
   // relations
   complex_relationships: ComplexRelationship[]
+  complex_relationships_count: number
+  complex_relationships_exists: boolean
 }

--- a/test/input/expectations/user-api-resource.ts
+++ b/test/input/expectations/user-api-resource.ts
@@ -15,6 +15,8 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  notifications_count: number
+  notifications_exists: boolean
 }
 export interface UserResult extends api.MetApiResults { data: User }
 export interface UserMetApiData extends api.MetApiData { data: User }

--- a/test/input/expectations/user-enums.ts
+++ b/test/input/expectations/user-enums.ts
@@ -15,6 +15,8 @@ export interface User {
   role_enum_traditional: RolesEnum
   // relations
   notifications: DatabaseNotification[]
+  notifications_count: number
+  notifications_exists: boolean
 }
 
 export const enum Roles {

--- a/test/input/expectations/user-fillables.ts
+++ b/test/input/expectations/user-fillables.ts
@@ -15,6 +15,8 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  notifications_count: number
+  notifications_exists: boolean
 }
 export type UserEditable = Pick<User, 'name' | 'email' | 'password' | 'role_traditional' | 'role_new'>
 

--- a/test/input/expectations/user-global.ts
+++ b/test/input/expectations/user-global.ts
@@ -19,6 +19,8 @@ declare global {
       role_enum_traditional: Roles
       // relations
       notifications: DatabaseNotification[]
+      notifications_count: number
+      notifications_exists: boolean
     }
 
     const Roles = {

--- a/test/input/expectations/user-no-hidden.ts
+++ b/test/input/expectations/user-no-hidden.ts
@@ -13,6 +13,8 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  notifications_count: number
+  notifications_exists: boolean
 }
 
 const Roles = {

--- a/test/input/expectations/user-optional-nullables.ts
+++ b/test/input/expectations/user-optional-nullables.ts
@@ -15,6 +15,8 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  notifications_count: number
+  notifications_exists: boolean
 }
 
 const Roles = {

--- a/test/input/expectations/user-optional-relations.ts
+++ b/test/input/expectations/user-optional-relations.ts
@@ -15,6 +15,8 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications?: DatabaseNotification[]
+  notifications_count: number
+  notifications_exists: boolean
 }
 
 const Roles = {

--- a/test/input/expectations/user-plurals.ts
+++ b/test/input/expectations/user-plurals.ts
@@ -15,6 +15,8 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotifications
+  notifications_count: number
+  notifications_exists: boolean
 }
 export type Users = User[]
 

--- a/test/input/expectations/user-timestamps-date.ts
+++ b/test/input/expectations/user-timestamps-date.ts
@@ -15,6 +15,8 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  notifications_count: number
+  notifications_exists: boolean
 }
 
 const Roles = {

--- a/test/input/expectations/user.ts
+++ b/test/input/expectations/user.ts
@@ -15,6 +15,8 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  notifications_count: number
+  notifications_exists: boolean
 }
 
 const Roles = {


### PR DESCRIPTION
Added four new config options (and corresponding CLI flags): --no-counts, --optional-counts, --no-exists, and --optional-exists.

These allow control over how countable and existence-based relations (e.g., users, flows, organization_invitations) are represented in the generated TypeScript interfaces.

**When enabled:**

- --no-counts: Omits all _count fields (e.g., users_count) from the output.
- --optional-counts: Makes all _count fields optional.
- --no-exists: Omits all _exists fields (e.g., users_exists) from the output.
- --optional-exists: Makes all _exists fields optional.

**NB**

- Default behavior includes all count and exists fields unless the corresponding flags/configs are used.
- Updated WriteRelationship class and test suite to respect these new config options, falling back to config values if CLI flags aren’t passed.
- All tests updated and passing.