### PR TITLE
Add sum support and fixes of previous comments/feedback

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ trim_trailing_whitespace = true
 
 [*.ts]
 indent_size = 2
+
+[*.json]
+insert_final_newline = false

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.12.3",
+            "version": "0.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba"
+                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/866551da34e9a618e64a819ee1e01c20d8a588ba",
-                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba",
+                "url": "https://api.github.com/repos/brick/math/zipball/fc7ed316430118cc7836bf45faff18d5dfc8de04",
+                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.12.3"
+                "source": "https://github.com/brick/math/tree/0.13.1"
             },
             "funding": [
                 {
@@ -64,7 +64,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-28T13:11:00+00:00"
+            "time": "2025-03-29T13:50:30+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -1056,20 +1056,20 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.15.0",
+            "version": "v12.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "2ef7fb183f18e547af4eb9f5a55b2ac1011f0b77"
+                "reference": "7d264a0dad2bfc5c154240b38e8ce9b2c4cdd14d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/2ef7fb183f18e547af4eb9f5a55b2ac1011f0b77",
-                "reference": "2ef7fb183f18e547af4eb9f5a55b2ac1011f0b77",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/7d264a0dad2bfc5c154240b38e8ce9b2c4cdd14d",
+                "reference": "7d264a0dad2bfc5c154240b38e8ce9b2c4cdd14d",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.11|^0.12",
+                "brick/math": "^0.11|^0.12|^0.13",
                 "composer-runtime-api": "^2.2",
                 "doctrine/inflector": "^2.0.5",
                 "dragonmantank/cron-expression": "^3.4",
@@ -1267,7 +1267,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-05-20T15:10:44+00:00"
+            "time": "2025-06-10T14:48:34+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -2045,16 +2045,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.9.1",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "ced71f79398ece168e24f7f7710462f462310d4d"
+                "reference": "c1397390dd0a7e0f11660f0ae20f753d88c1f3d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/ced71f79398ece168e24f7f7710462f462310d4d",
-                "reference": "ced71f79398ece168e24f7f7710462f462310d4d",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/c1397390dd0a7e0f11660f0ae20f753d88c1f3d9",
+                "reference": "c1397390dd0a7e0f11660f0ae20f753d88c1f3d9",
                 "shasum": ""
             },
             "require": {
@@ -2062,9 +2062,9 @@
                 "ext-json": "*",
                 "php": "^8.1",
                 "psr/clock": "^1.0",
-                "symfony/clock": "^6.3 || ^7.0",
+                "symfony/clock": "^6.3.12 || ^7.0",
                 "symfony/polyfill-mbstring": "^1.0",
-                "symfony/translation": "^4.4.18 || ^5.2.1|| ^6.0 || ^7.0"
+                "symfony/translation": "^4.4.18 || ^5.2.1 || ^6.0 || ^7.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -2072,14 +2072,13 @@
             "require-dev": {
                 "doctrine/dbal": "^3.6.3 || ^4.0",
                 "doctrine/orm": "^2.15.2 || ^3.0",
-                "friendsofphp/php-cs-fixer": "^3.57.2",
+                "friendsofphp/php-cs-fixer": "^3.75.0",
                 "kylekatarnls/multi-tester": "^2.5.3",
-                "ondrejmirtes/better-reflection": "^6.25.0.4",
                 "phpmd/phpmd": "^2.15.0",
-                "phpstan/extension-installer": "^1.3.1",
-                "phpstan/phpstan": "^1.11.2",
-                "phpunit/phpunit": "^10.5.20",
-                "squizlabs/php_codesniffer": "^3.9.0"
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.17",
+                "phpunit/phpunit": "^10.5.46",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "bin": [
                 "bin/carbon"
@@ -2147,7 +2146,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-01T19:51:51+00:00"
+            "time": "2025-06-12T10:24:28+00:00"
         },
         {
             "name": "nette/schema",
@@ -2213,16 +2212,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.6",
+            "version": "v4.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "ce708655043c7050eb050df361c5e313cf708309"
+                "reference": "e67c4061eb40b9c113b218214e42cb5a0dda28f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/ce708655043c7050eb050df361c5e313cf708309",
-                "reference": "ce708655043c7050eb050df361c5e313cf708309",
+                "url": "https://api.github.com/repos/nette/utils/zipball/e67c4061eb40b9c113b218214e42cb5a0dda28f2",
+                "reference": "e67c4061eb40b9c113b218214e42cb5a0dda28f2",
                 "shasum": ""
             },
             "require": {
@@ -2293,9 +2292,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.6"
+                "source": "https://github.com/nette/utils/tree/v4.0.7"
             },
-            "time": "2025-03-30T21:06:30+00:00"
+            "time": "2025-06-03T04:55:08+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -2993,20 +2992,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.7.6",
+            "version": "4.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "91039bc1faa45ba123c4328958e620d382ec7088"
+                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/91039bc1faa45ba123c4328958e620d382ec7088",
-                "reference": "91039bc1faa45ba123c4328958e620d382ec7088",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
+                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12",
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13",
                 "ext-json": "*",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
@@ -3015,26 +3014,23 @@
                 "rhumsaa/uuid": "self.version"
             },
             "require-dev": {
-                "captainhook/captainhook": "^5.10",
+                "captainhook/captainhook": "^5.25",
                 "captainhook/plugin-composer": "^5.3",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "doctrine/annotations": "^1.8",
-                "ergebnis/composer-normalize": "^2.15",
-                "mockery/mockery": "^1.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "ergebnis/composer-normalize": "^2.47",
+                "mockery/mockery": "^1.6",
                 "paragonie/random-lib": "^2",
-                "php-mock/php-mock": "^2.2",
-                "php-mock/php-mock-mockery": "^1.3",
-                "php-parallel-lint/php-parallel-lint": "^1.1",
-                "phpbench/phpbench": "^1.0",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-mockery": "^1.1",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpunit/phpunit": "^8.5 || ^9",
-                "ramsey/composer-repl": "^1.4",
-                "slevomat/coding-standard": "^8.4",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.9"
+                "php-mock/php-mock": "^2.6",
+                "php-mock/php-mock-mockery": "^1.5",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpbench/phpbench": "^1.2.14",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "slevomat/coding-standard": "^8.18",
+                "squizlabs/php_codesniffer": "^3.13"
             },
             "suggest": {
                 "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
@@ -3069,23 +3065,13 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.7.6"
+                "source": "https://github.com/ramsey/uuid/tree/4.8.1"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/ramsey",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/ramsey/uuid",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-04-27T21:32:50+00:00"
+            "time": "2025-06-01T06:28:46+00:00"
         },
         {
             "name": "symfony/clock",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
@@ -3139,7 +3125,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.2.0"
+                "source": "https://github.com/symfony/clock/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3159,23 +3145,24 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "0e2e3f38c192e93e622e41ec37f4ca70cfedf218"
+                "reference": "66c1440edf6f339fd82ed6c7caa76cb006211b44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/0e2e3f38c192e93e622e41ec37f4ca70cfedf218",
-                "reference": "0e2e3f38c192e93e622e41ec37f4ca70cfedf218",
+                "url": "https://api.github.com/repos/symfony/console/zipball/66c1440edf6f339fd82ed6c7caa76cb006211b44",
+                "reference": "66c1440edf6f339fd82ed6c7caa76cb006211b44",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^6.4|^7.0"
+                "symfony/string": "^7.2"
             },
             "conflict": {
                 "symfony/dependency-injection": "<6.4",
@@ -3232,7 +3219,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.2.6"
+                "source": "https://github.com/symfony/console/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3248,11 +3235,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-07T19:09:28+00:00"
+            "time": "2025-05-24T10:34:04+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -3297,7 +3284,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v7.2.0"
+                "source": "https://github.com/symfony/css-selector/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3317,16 +3304,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
                 "shasum": ""
             },
             "require": {
@@ -3339,7 +3326,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -3364,7 +3351,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -3380,20 +3367,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.2.5",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "102be5e6a8e4f4f3eb3149bcbfa33a80d1ee374b"
+                "reference": "cf68d225bc43629de4ff54778029aee6dc191b83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/102be5e6a8e4f4f3eb3149bcbfa33a80d1ee374b",
-                "reference": "102be5e6a8e4f4f3eb3149bcbfa33a80d1ee374b",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/cf68d225bc43629de4ff54778029aee6dc191b83",
+                "reference": "cf68d225bc43629de4ff54778029aee6dc191b83",
                 "shasum": ""
             },
             "require": {
@@ -3406,9 +3393,11 @@
                 "symfony/http-kernel": "<6.4"
             },
             "require-dev": {
+                "symfony/console": "^6.4|^7.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/serializer": "^6.4|^7.0"
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/webpack-encore-bundle": "^1.0|^2.0"
             },
             "bin": [
                 "Resources/bin/patch-type-declarations"
@@ -3439,7 +3428,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.2.5"
+                "source": "https://github.com/symfony/error-handler/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3455,20 +3444,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-03T07:12:39+00:00"
+            "time": "2025-05-29T07:19:49+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1"
+                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/910c5db85a5356d0fea57680defec4e99eb9c8c1",
-                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/497f73ac996a598c92409b44ac43b6690c4f666d",
+                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d",
                 "shasum": ""
             },
             "require": {
@@ -3519,7 +3508,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.2.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3535,20 +3524,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2025-04-22T09:11:45+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f"
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7642f5e970b672283b7823222ae8ef8bbc160b9f",
-                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
                 "shasum": ""
             },
             "require": {
@@ -3562,7 +3551,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -3595,7 +3584,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -3611,20 +3600,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.2.2",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "87a71856f2f56e4100373e92529eed3171695cfb"
+                "reference": "ec2344cf77a48253bbca6939aa3d2477773ea63d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/87a71856f2f56e4100373e92529eed3171695cfb",
-                "reference": "87a71856f2f56e4100373e92529eed3171695cfb",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ec2344cf77a48253bbca6939aa3d2477773ea63d",
+                "reference": "ec2344cf77a48253bbca6939aa3d2477773ea63d",
                 "shasum": ""
             },
             "require": {
@@ -3659,7 +3648,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.2.2"
+                "source": "https://github.com/symfony/finder/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3675,20 +3664,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-30T19:00:17+00:00"
+            "time": "2024-12-30T19:00:26+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "6023ec7607254c87c5e69fb3558255aca440d72b"
+                "reference": "4236baf01609667d53b20371486228231eb135fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6023ec7607254c87c5e69fb3558255aca440d72b",
-                "reference": "6023ec7607254c87c5e69fb3558255aca440d72b",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/4236baf01609667d53b20371486228231eb135fd",
+                "reference": "4236baf01609667d53b20371486228231eb135fd",
                 "shasum": ""
             },
             "require": {
@@ -3705,6 +3694,7 @@
                 "doctrine/dbal": "^3.6|^4",
                 "predis/predis": "^1.1|^2.0",
                 "symfony/cache": "^6.4.12|^7.1.5",
+                "symfony/clock": "^6.4|^7.0",
                 "symfony/dependency-injection": "^6.4|^7.0",
                 "symfony/expression-language": "^6.4|^7.0",
                 "symfony/http-kernel": "^6.4|^7.0",
@@ -3737,7 +3727,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.2.6"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3753,20 +3743,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-09T08:14:01+00:00"
+            "time": "2025-05-12T14:48:23+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "f9dec01e6094a063e738f8945ef69c0cfcf792ec"
+                "reference": "ac7b8e163e8c83dce3abcc055a502d4486051a9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f9dec01e6094a063e738f8945ef69c0cfcf792ec",
-                "reference": "f9dec01e6094a063e738f8945ef69c0cfcf792ec",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/ac7b8e163e8c83dce3abcc055a502d4486051a9f",
+                "reference": "ac7b8e163e8c83dce3abcc055a502d4486051a9f",
                 "shasum": ""
             },
             "require": {
@@ -3774,8 +3764,8 @@
                 "psr/log": "^1|^2|^3",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/error-handler": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^7.3",
+                "symfony/http-foundation": "^7.3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
@@ -3851,7 +3841,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.2.6"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3867,20 +3857,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-02T09:04:03+00:00"
+            "time": "2025-05-29T07:47:32+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "998692469d6e698c6eadc7ef37a6530a9eabb356"
+                "reference": "0f375bbbde96ae8c78e4aa3e63aabd486e33364c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/998692469d6e698c6eadc7ef37a6530a9eabb356",
-                "reference": "998692469d6e698c6eadc7ef37a6530a9eabb356",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/0f375bbbde96ae8c78e4aa3e63aabd486e33364c",
+                "reference": "0f375bbbde96ae8c78e4aa3e63aabd486e33364c",
                 "shasum": ""
             },
             "require": {
@@ -3931,7 +3921,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.2.6"
+                "source": "https://github.com/symfony/mailer/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3947,20 +3937,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-04T09:50:51+00:00"
+            "time": "2025-04-04T09:51:09+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "706e65c72d402539a072d0d6ad105fff6c161ef1"
+                "reference": "0e7b19b2f399c31df0cdbe5d8cbf53f02f6cfcd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/706e65c72d402539a072d0d6ad105fff6c161ef1",
-                "reference": "706e65c72d402539a072d0d6ad105fff6c161ef1",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/0e7b19b2f399c31df0cdbe5d8cbf53f02f6cfcd9",
+                "reference": "0e7b19b2f399c31df0cdbe5d8cbf53f02f6cfcd9",
                 "shasum": ""
             },
             "require": {
@@ -4015,7 +4005,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.2.6"
+                "source": "https://github.com/symfony/mime/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -4031,7 +4021,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-27T13:34:41+00:00"
+            "time": "2025-02-19T08:51:26+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4672,16 +4662,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.2.5",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "87b7c93e57df9d8e39a093d32587702380ff045d"
+                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/87b7c93e57df9d8e39a093d32587702380ff045d",
-                "reference": "87b7c93e57df9d8e39a093d32587702380ff045d",
+                "url": "https://api.github.com/repos/symfony/process/zipball/40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
+                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
                 "shasum": ""
             },
             "require": {
@@ -4713,7 +4703,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.2.5"
+                "source": "https://github.com/symfony/process/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -4729,20 +4719,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-13T12:21:46+00:00"
+            "time": "2025-04-17T09:11:12+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.2.3",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "ee9a67edc6baa33e5fae662f94f91fd262930996"
+                "reference": "8e213820c5fea844ecea29203d2a308019007c15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/ee9a67edc6baa33e5fae662f94f91fd262930996",
-                "reference": "ee9a67edc6baa33e5fae662f94f91fd262930996",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/8e213820c5fea844ecea29203d2a308019007c15",
+                "reference": "8e213820c5fea844ecea29203d2a308019007c15",
                 "shasum": ""
             },
             "require": {
@@ -4794,7 +4784,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.2.3"
+                "source": "https://github.com/symfony/routing/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -4810,20 +4800,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-17T10:56:55+00:00"
+            "time": "2025-05-24T20:43:28+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
                 "shasum": ""
             },
             "require": {
@@ -4841,7 +4831,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -4877,7 +4867,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -4893,20 +4883,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2025-04-25T09:37:31+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "a214fe7d62bd4df2a76447c67c6b26e1d5e74931"
+                "reference": "f3570b8c61ca887a9e2938e85cb6458515d2b125"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/a214fe7d62bd4df2a76447c67c6b26e1d5e74931",
-                "reference": "a214fe7d62bd4df2a76447c67c6b26e1d5e74931",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f3570b8c61ca887a9e2938e85cb6458515d2b125",
+                "reference": "f3570b8c61ca887a9e2938e85cb6458515d2b125",
                 "shasum": ""
             },
             "require": {
@@ -4964,7 +4954,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.2.6"
+                "source": "https://github.com/symfony/string/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -4980,20 +4970,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-20T20:18:16+00:00"
+            "time": "2025-04-20T20:19:01+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "e7fd8e2a4239b79a0fd9fb1fef3e0e7f969c6dc6"
+                "reference": "4aba29076a29a3aa667e09b791e5f868973a8667"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/e7fd8e2a4239b79a0fd9fb1fef3e0e7f969c6dc6",
-                "reference": "e7fd8e2a4239b79a0fd9fb1fef3e0e7f969c6dc6",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/4aba29076a29a3aa667e09b791e5f868973a8667",
+                "reference": "4aba29076a29a3aa667e09b791e5f868973a8667",
                 "shasum": ""
             },
             "require": {
@@ -5003,6 +4993,7 @@
                 "symfony/translation-contracts": "^2.5|^3.0"
             },
             "conflict": {
+                "nikic/php-parser": "<5.0",
                 "symfony/config": "<6.4",
                 "symfony/console": "<6.4",
                 "symfony/dependency-injection": "<6.4",
@@ -5016,7 +5007,7 @@
                 "symfony/translation-implementation": "2.3|3.0"
             },
             "require-dev": {
-                "nikic/php-parser": "^4.18|^5.0",
+                "nikic/php-parser": "^5.0",
                 "psr/log": "^1|^2|^3",
                 "symfony/config": "^6.4|^7.0",
                 "symfony/console": "^6.4|^7.0",
@@ -5059,7 +5050,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.2.6"
+                "source": "https://github.com/symfony/translation/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -5075,20 +5066,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-07T19:09:28+00:00"
+            "time": "2025-05-29T07:19:49+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c"
+                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/4667ff3bd513750603a09c8dedbea942487fb07c",
-                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
+                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
                 "shasum": ""
             },
             "require": {
@@ -5101,7 +5092,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -5137,7 +5128,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -5153,20 +5144,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-27T08:32:26+00:00"
         },
         {
             "name": "symfony/uid",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "2d294d0c48df244c71c105a169d0190bfb080426"
+                "reference": "7beeb2b885cd584cd01e126c5777206ae4c3c6a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/2d294d0c48df244c71c105a169d0190bfb080426",
-                "reference": "2d294d0c48df244c71c105a169d0190bfb080426",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/7beeb2b885cd584cd01e126c5777206ae4c3c6a3",
+                "reference": "7beeb2b885cd584cd01e126c5777206ae4c3c6a3",
                 "shasum": ""
             },
             "require": {
@@ -5211,7 +5202,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.2.0"
+                "source": "https://github.com/symfony/uid/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -5227,24 +5218,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2025-05-24T14:28:13+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "9c46038cd4ed68952166cf7001b54eb539184ccb"
+                "reference": "548f6760c54197b1084e1e5c71f6d9d523f2f78e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9c46038cd4ed68952166cf7001b54eb539184ccb",
-                "reference": "9c46038cd4ed68952166cf7001b54eb539184ccb",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/548f6760c54197b1084e1e5c71f6d9d523f2f78e",
+                "reference": "548f6760c54197b1084e1e5c71f6d9d523f2f78e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
@@ -5294,7 +5286,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.2.6"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -5310,7 +5302,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-09T08:14:01+00:00"
+            "time": "2025-04-27T18:39:23+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -6026,16 +6018,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.18.0",
+            "version": "2.18.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e"
+                "reference": "89dabca1490bc77dbcab41c2b20968c7e44bf7c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e",
-                "reference": "a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/89dabca1490bc77dbcab41c2b20968c7e44bf7c3",
+                "reference": "89dabca1490bc77dbcab41c2b20968c7e44bf7c3",
                 "shasum": ""
             },
             "require": {
@@ -6085,7 +6077,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.18.0"
+                "source": "https://github.com/filp/whoops/tree/2.18.2"
             },
             "funding": [
                 {
@@ -6093,7 +6085,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-15T12:00:00+00:00"
+            "time": "2025-06-11T20:42:19+00:00"
         },
         {
             "name": "grasmash/expander",
@@ -6241,16 +6233,16 @@
         },
         {
             "name": "larastan/larastan",
-            "version": "v3.4.0",
+            "version": "v3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/larastan/larastan.git",
-                "reference": "1042fa0c2ee490bb6da7381f3323f7292ad68222"
+                "reference": "36706736a0c51d3337478fab9c919d78d2e03404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/1042fa0c2ee490bb6da7381f3323f7292ad68222",
-                "reference": "1042fa0c2ee490bb6da7381f3323f7292ad68222",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/36706736a0c51d3337478fab9c919d78d2e03404",
+                "reference": "36706736a0c51d3337478fab9c919d78d2e03404",
                 "shasum": ""
             },
             "require": {
@@ -6318,7 +6310,7 @@
             ],
             "support": {
                 "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v3.4.0"
+                "source": "https://github.com/larastan/larastan/tree/v3.4.2"
             },
             "funding": [
                 {
@@ -6326,20 +6318,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-22T09:44:59+00:00"
+            "time": "2025-06-10T09:34:58+00:00"
         },
         {
             "name": "laravel/pail",
-            "version": "v1.2.2",
+            "version": "v1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pail.git",
-                "reference": "f31f4980f52be17c4667f3eafe034e6826787db2"
+                "reference": "8cc3d575c1f0e57eeb923f366a37528c50d2385a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pail/zipball/f31f4980f52be17c4667f3eafe034e6826787db2",
-                "reference": "f31f4980f52be17c4667f3eafe034e6826787db2",
+                "url": "https://api.github.com/repos/laravel/pail/zipball/8cc3d575c1f0e57eeb923f366a37528c50d2385a",
+                "reference": "8cc3d575c1f0e57eeb923f366a37528c50d2385a",
                 "shasum": ""
             },
             "require": {
@@ -6359,7 +6351,7 @@
                 "orchestra/testbench-core": "^8.13|^9.0|^10.0",
                 "pestphp/pest": "^2.20|^3.0",
                 "pestphp/pest-plugin-type-coverage": "^2.3|^3.0",
-                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan": "^1.12.27",
                 "symfony/var-dumper": "^6.3|^7.0"
             },
             "type": "library",
@@ -6395,6 +6387,7 @@
             "description": "Easily delve into your Laravel application's log files directly from the command line.",
             "homepage": "https://github.com/laravel/pail",
             "keywords": [
+                "dev",
                 "laravel",
                 "logs",
                 "php",
@@ -6404,7 +6397,7 @@
                 "issues": "https://github.com/laravel/pail/issues",
                 "source": "https://github.com/laravel/pail"
             },
-            "time": "2025-01-28T15:15:15+00:00"
+            "time": "2025-06-05T13:55:57+00:00"
         },
         {
             "name": "laravel/pint",
@@ -6765,16 +6758,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
                 "shasum": ""
             },
             "require": {
@@ -6817,29 +6810,29 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-05-31T08:24:38+00:00"
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.8.0",
+            "version": "v8.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "4cf9f3b47afff38b139fb79ce54fc71799022ce8"
+                "reference": "44ccb82e3e21efb5446748d2a3c81a030ac22bd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/4cf9f3b47afff38b139fb79ce54fc71799022ce8",
-                "reference": "4cf9f3b47afff38b139fb79ce54fc71799022ce8",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/44ccb82e3e21efb5446748d2a3c81a030ac22bd5",
+                "reference": "44ccb82e3e21efb5446748d2a3c81a030ac22bd5",
                 "shasum": ""
             },
             "require": {
-                "filp/whoops": "^2.18.0",
-                "nunomaduro/termwind": "^2.3.0",
+                "filp/whoops": "^2.18.1",
+                "nunomaduro/termwind": "^2.3.1",
                 "php": "^8.2.0",
-                "symfony/console": "^7.2.5"
+                "symfony/console": "^7.3.0"
             },
             "conflict": {
                 "laravel/framework": "<11.44.2 || >=13.0.0",
@@ -6847,15 +6840,15 @@
             },
             "require-dev": {
                 "brianium/paratest": "^7.8.3",
-                "larastan/larastan": "^3.2",
-                "laravel/framework": "^11.44.2 || ^12.6",
-                "laravel/pint": "^1.21.2",
-                "laravel/sail": "^1.41.0",
-                "laravel/sanctum": "^4.0.8",
+                "larastan/larastan": "^3.4.2",
+                "laravel/framework": "^11.44.2 || ^12.18",
+                "laravel/pint": "^1.22.1",
+                "laravel/sail": "^1.43.1",
+                "laravel/sanctum": "^4.1.1",
                 "laravel/tinker": "^2.10.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.1",
-                "pestphp/pest": "^3.8.0",
-                "sebastian/environment": "^7.2.0 || ^8.0"
+                "orchestra/testbench-core": "^9.12.0 || ^10.4",
+                "pestphp/pest": "^3.8.2",
+                "sebastian/environment": "^7.2.1 || ^8.0"
             },
             "type": "library",
             "extra": {
@@ -6918,7 +6911,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-04-03T14:33:09+00:00"
+            "time": "2025-06-11T01:04:21+00:00"
         },
         {
             "name": "orchestra/canvas",
@@ -7061,16 +7054,16 @@
         },
         {
             "name": "orchestra/sidekick",
-            "version": "v1.2.8",
+            "version": "v1.2.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/sidekick.git",
-                "reference": "4e01680e7109596072f22382626970ba1a2ab92a"
+                "reference": "c182e9f91d7aa68417eae0585e004fbbc7beac26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/sidekick/zipball/4e01680e7109596072f22382626970ba1a2ab92a",
-                "reference": "4e01680e7109596072f22382626970ba1a2ab92a",
+                "url": "https://api.github.com/repos/orchestral/sidekick/zipball/c182e9f91d7aa68417eae0585e004fbbc7beac26",
+                "reference": "c182e9f91d7aa68417eae0585e004fbbc7beac26",
                 "shasum": ""
             },
             "require": {
@@ -7112,22 +7105,22 @@
             "description": "Packages Toolkit Utilities and Helpers for Laravel",
             "support": {
                 "issues": "https://github.com/orchestral/sidekick/issues",
-                "source": "https://github.com/orchestral/sidekick/tree/v1.2.8"
+                "source": "https://github.com/orchestral/sidekick/tree/v1.2.12"
             },
-            "time": "2025-05-21T11:25:24+00:00"
+            "time": "2025-06-08T03:58:04+00:00"
         },
         {
             "name": "orchestra/testbench",
-            "version": "v10.3.0",
+            "version": "v10.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "6d0930e33724809a2dbd3c9ecd686295b899e6c9"
+                "reference": "36674005fb1b5cddfd953b8c440507394af8695d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/6d0930e33724809a2dbd3c9ecd686295b899e6c9",
-                "reference": "6d0930e33724809a2dbd3c9ecd686295b899e6c9",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/36674005fb1b5cddfd953b8c440507394af8695d",
+                "reference": "36674005fb1b5cddfd953b8c440507394af8695d",
                 "shasum": ""
             },
             "require": {
@@ -7135,7 +7128,7 @@
                 "fakerphp/faker": "^1.23",
                 "laravel/framework": "^12.8.0",
                 "mockery/mockery": "^1.6.10",
-                "orchestra/testbench-core": "^10.3.0",
+                "orchestra/testbench-core": "^10.4.0",
                 "orchestra/workbench": "^10.0.6",
                 "php": "^8.2",
                 "phpunit/phpunit": "^11.5.3|^12.0.1",
@@ -7167,27 +7160,27 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/testbench/issues",
-                "source": "https://github.com/orchestral/testbench/tree/v10.3.0"
+                "source": "https://github.com/orchestral/testbench/tree/v10.4.0"
             },
-            "time": "2025-05-12T06:36:03+00:00"
+            "time": "2025-06-08T23:29:04+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v10.3.0",
+            "version": "v10.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "3cacf7bc512665b9eb6d2380bb4433574458a557"
+                "reference": "d1c45a7be15c4d99fb7d48685b038dd39acc7b84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/3cacf7bc512665b9eb6d2380bb4433574458a557",
-                "reference": "3cacf7bc512665b9eb6d2380bb4433574458a557",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/d1c45a7be15c4d99fb7d48685b038dd39acc7b84",
+                "reference": "d1c45a7be15c4d99fb7d48685b038dd39acc7b84",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
-                "orchestra/sidekick": "^1.1.5|^1.2.0",
+                "orchestra/sidekick": "~1.1.16|^1.2.12",
                 "php": "^8.2",
                 "symfony/deprecation-contracts": "^2.5|^3.0",
                 "symfony/polyfill-php83": "^1.32"
@@ -7197,7 +7190,7 @@
                 "laravel/framework": "<12.8.0|>=13.0.0",
                 "laravel/serializable-closure": "<1.3.0|>=2.0.0 <2.0.3|>=3.0.0",
                 "nunomaduro/collision": "<8.0.0|>=9.0.0",
-                "phpunit/phpunit": "<10.5.35|>=11.0.0 <11.5.3|12.0.0|>=12.2.0"
+                "phpunit/phpunit": "<10.5.35|>=11.0.0 <11.5.3|12.0.0|>=12.3.0"
             },
             "require-dev": {
                 "fakerphp/faker": "^1.24",
@@ -7262,7 +7255,7 @@
                 "issues": "https://github.com/orchestral/testbench/issues",
                 "source": "https://github.com/orchestral/testbench-core"
             },
-            "time": "2025-05-12T05:41:57+00:00"
+            "time": "2025-06-08T04:36:36+00:00"
         },
         {
             "name": "orchestra/workbench",
@@ -7608,16 +7601,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.16",
+            "version": "2.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b8c1cf533cba0c305d91c6ccd23f3dd0566ba5f9"
+                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b8c1cf533cba0c305d91c6ccd23f3dd0566ba5f9",
-                "reference": "b8c1cf533cba0c305d91c6ccd23f3dd0566ba5f9",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/89b5ef665716fa2a52ecd2633f21007a6a349053",
+                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053",
                 "shasum": ""
             },
             "require": {
@@ -7662,7 +7655,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-16T09:40:10+00:00"
+            "time": "2025-05-21T20:55:28+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -8036,16 +8029,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.21",
+            "version": "11.5.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d565e2cdc21a7db9dc6c399c1fc2083b8010f289"
+                "reference": "86ebcd8a3dbcd1857d88505109b2a2b376501cde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d565e2cdc21a7db9dc6c399c1fc2083b8010f289",
-                "reference": "d565e2cdc21a7db9dc6c399c1fc2083b8010f289",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/86ebcd8a3dbcd1857d88505109b2a2b376501cde",
+                "reference": "86ebcd8a3dbcd1857d88505109b2a2b376501cde",
                 "shasum": ""
             },
             "require": {
@@ -8117,7 +8110,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.21"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.23"
             },
             "funding": [
                 {
@@ -8141,7 +8134,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-21T12:35:00+00:00"
+            "time": "2025-06-13T05:47:49+00:00"
         },
         {
             "name": "psy/psysh",
@@ -9214,7 +9207,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -9260,7 +9253,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.2.0"
+                "source": "https://github.com/symfony/filesystem/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -9356,16 +9349,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "0feafffb843860624ddfd13478f481f4c3cd8b23"
+                "reference": "cea40a48279d58dc3efee8112634cb90141156c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0feafffb843860624ddfd13478f481f4c3cd8b23",
-                "reference": "0feafffb843860624ddfd13478f481f4c3cd8b23",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/cea40a48279d58dc3efee8112634cb90141156c2",
+                "reference": "cea40a48279d58dc3efee8112634cb90141156c2",
                 "shasum": ""
             },
             "require": {
@@ -9408,7 +9401,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.2.6"
+                "source": "https://github.com/symfony/yaml/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -9424,7 +9417,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-04T10:10:11+00:00"
+            "time": "2025-04-04T10:10:33+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/modeltyper.php
+++ b/config/modeltyper.php
@@ -168,6 +168,28 @@ return [
     'optional-exists' => false,
 
     /*
+     * --------------------------------------------------------------------------
+     * Exclude Sums Attributes
+     * --------------------------------------------------------------------------
+     *
+     * Determines whether to exclude the sums property from model TypeScript
+     * definitions. Sums are typically used to aggregate values across
+     * relationships.
+     */
+    'no-sums' => false,
+
+    /*
+     * --------------------------------------------------------------------------
+     * Make Sums Attributes Optional
+     * --------------------------------------------------------------------------
+     *
+     * Determines whether the sums property should be optional in the
+     * TypeScript definitions. This allows for more flexibility in handling
+     * models that may not have aggregated values.
+     */
+    'optional-sums' => false,
+
+    /*
     |--------------------------------------------------------------------------
     | Output Timestamps as Date Object Types
     |--------------------------------------------------------------------------

--- a/pint.json
+++ b/pint.json
@@ -4,7 +4,8 @@
         "no_useless_else": true,
         "concat_space": {
             "spacing": "one"
-        }
+        },
+        "declare_strict_types": false
     },
     "exclude": [
         "test/input"

--- a/readme.md
+++ b/readme.md
@@ -140,12 +140,40 @@ protected function firstName(): Attribute
 - --optional-counts : Make relationship counts optional fields on the model type
 - --no-exists : Do not include exists for relationships
 - --optional-exists : Make relationship exists optional fields on the model type
+- --no-sums : Do not include sums for relationships
+- --optional-sums : Make relationship sums optional fields on the model type
 - --timestamps-date : Output timestamps as a Date object type
 - --optional-nullables : Output nullable attributes as optional fields
 - --api-resources : Output api.MetApi interfaces
 - --fillables : Output model fillables
 - --fillable-suffix= : Appends to fillables
 - --ignore-config : Ignore options set in config
+
+
+### Sum Aggregates for Relationships
+
+Model Typer supports generating sum aggregates for Eloquent relationships. If a related model includes a summed value (e.g., the total number of likes on a user’s posts), this sum will be reflected in the generated output.
+
+To enable this, define the sum relationship and target column using the $sums property on your model:
+
+```php
+protected $sums = [
+// Format: 'relationship' => 'column_to_sum'
+'posts' => 'likes',
+];
+```
+
+This will generate a corresponding field in the TypeScript interface:
+
+```ts
+export interface User {
+...
+// Sum of `likes` from related `posts`
+posts_sum_likes: number | null;
+}
+```
+
+This allows you to work with pre-calculated relationship totals directly in your frontend types.
 
 ### Custom Interfaces
 

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,13 @@ export interface User {
     initials: string;
     // relations
     teams: Teams;
+    posts: Posts;
+    // counts
+    teams_count: number;
+    posts_count: number;
+    // exists
+    teams_exists: boolean;
+    posts_exists: boolean;
 }
 export type Users = Array<User>;
 
@@ -77,8 +84,48 @@ export interface Team {
     url: string;
     // relations
     users: Users;
+    // counts
+    users_count: number;
+    // exists
+    users_exists: boolean;
 }
 export type Teams = Array<Team>;
+
+export interface Post {
+    // columns
+    id: number;
+    user_id: number;
+    title: string;
+    content: string;
+    created_at?: Date;
+    updated_at?: Date;
+    // mutators
+    summary: string;
+    // relations
+    user: User;
+    comments: Comments;
+    // counts
+    comments_count: number;
+    // exists
+    comments_exists: boolean;
+    // sums
+    comments_sum_likes: number | null;
+}
+export type Posts = Array<Post>;
+
+export interface Comment {
+    // columns
+    id: number;
+    post_id: number;
+    content: string;
+    created_at?: Date;
+    updated_at?: Date;
+    // mutators
+    summary: string;
+    // relations
+    post: Post;
+}
+export type Comments = Array<Comment>;
 ```
 
 ### How does it work?

--- a/src/Actions/BuildModelDetails.php
+++ b/src/Actions/BuildModelDetails.php
@@ -80,7 +80,7 @@ class BuildModelDetails
             'relations' => $relations,
             'interfaces' => $interfaces,
             'imports' => $imports,
-            'sums' => $sums
+            'sums' => $sums,
         ];
     }
 

--- a/src/Actions/BuildModelDetails.php
+++ b/src/Actions/BuildModelDetails.php
@@ -4,8 +4,11 @@ namespace FumeApp\ModelTyper\Actions;
 
 use FumeApp\ModelTyper\Traits\ClassBaseName;
 use FumeApp\ModelTyper\Traits\ModelRefClass;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use ReflectionClass;
 use ReflectionException;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -16,7 +19,7 @@ class BuildModelDetails
     /**
      * Build the model details.
      *
-     * @return array{reflectionModel: \ReflectionClass, name: string, columns: \Illuminate\Support\Collection, nonColumns: \Illuminate\Support\Collection, relations: \Illuminate\Support\Collection, interfaces: \Illuminate\Support\Collection, imports: \Illuminate\Support\Collection}|null
+     * @return array{reflectionModel: ReflectionClass, name: string, columns: Collection, nonColumns: Collection, relations: Collection, interfaces: Collection, imports: Collection, sums: Collection}|null
      *
      * @throws ReflectionException
      */
@@ -57,6 +60,11 @@ class BuildModelDetails
             ->unique()
             ->values();
 
+        $sums = collect($laravelModel->sums ?? [])->map(fn ($column, $relation) => [
+            'relation' => $relation,
+            'column' => $column,
+        ])->values();
+
         // Override all columns, mutators and relationships with custom interfaces
         $columns = $this->overrideCollectionWithInterfaces($columns, $interfaces);
 
@@ -72,11 +80,12 @@ class BuildModelDetails
             'relations' => $relations,
             'interfaces' => $interfaces,
             'imports' => $imports,
+            'sums' => $sums
         ];
     }
 
     /**
-     * @return array{"class": class-string<\Illuminate\Database\Eloquent\Model>, database: string, table: string, policy: class-string|null, attributes: \Illuminate\Support\Collection, relations: \Illuminate\Support\Collection, events: \Illuminate\Support\Collection, observers: \Illuminate\Support\Collection, collection: class-string<\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>>, builder: class-string<\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>>}|null
+     * @return array{"class": class-string<Model>, database: string, table: string, policy: class-string|null, attributes: Collection, relations: Collection, events: Collection, observers: Collection, collection: class-string<\Illuminate\Database\Eloquent\Collection<Model>>, builder: class-string<Builder<Model>>}|null
      */
     private function getModelDetails(SplFileInfo $modelFile): ?array
     {

--- a/src/Actions/GenerateCliOutput.php
+++ b/src/Actions/GenerateCliOutput.php
@@ -32,8 +32,9 @@ class GenerateCliOutput
     /**
      * Output the command in the CLI.
      *
-     * @param Collection<int, SplFileInfo> $models
-     * @param array<string, string> $mappings
+     * @param  Collection<int, SplFileInfo>  $models
+     * @param  array<string, string>  $mappings
+     *
      * @throws \ReflectionException
      */
     public function __invoke(Collection $models, array $mappings, bool $global = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $noSums = false, bool $optionalSums = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string

--- a/src/Actions/GenerateCliOutput.php
+++ b/src/Actions/GenerateCliOutput.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace FumeApp\ModelTyper\Actions;
 
 use FumeApp\ModelTyper\Traits\ClassBaseName;
@@ -10,10 +8,9 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use ReflectionClass;
-use ReflectionException;
 use Symfony\Component\Finder\SplFileInfo;
 
-final class GenerateCliOutput
+class GenerateCliOutput
 {
     use ClassBaseName;
     use ModelRefClass;
@@ -35,24 +32,26 @@ final class GenerateCliOutput
     /**
      * Output the command in the CLI.
      *
-     * @param  Collection<int, SplFileInfo>  $models
-     * @param  array<string, string>  $mappings
-     *
-     * @throws ReflectionException
+     * @param Collection<int, SplFileInfo> $models
+     * @param array<string, string> $mappings
+     * @throws \ReflectionException
      */
-    public function __invoke(Collection $models, array $mappings, bool $global = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
+    public function __invoke(Collection $models, array $mappings, bool $global = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $noSums = false, bool $optionalSums = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
     {
         $modelBuilder = app(BuildModelDetails::class);
         $colAttrWriter = app(WriteColumnAttribute::class);
         $relationWriter = app(WriteRelationship::class);
+        $countWriter = app(WriteCount::class);
+        $existWriter = app(WriteExist::class);
+        $sumWriter = app(WriteSum::class);
 
         if ($global) {
             $namespace = Config::get('modeltyper.global-namespace', 'models');
-            $this->output .= 'export {}'.PHP_EOL.'declare global {'.PHP_EOL."  export namespace {$namespace} {".PHP_EOL.PHP_EOL;
+            $this->output .= 'export {}' . PHP_EOL . 'declare global {' . PHP_EOL . "  export namespace {$namespace} {" . PHP_EOL . PHP_EOL;
             $this->indent = '    ';
         }
 
-        $models->each(function (SplFileInfo $model) use ($mappings, $modelBuilder, $colAttrWriter, $relationWriter, $plurals, $apiResources, $optionalRelations, $noRelations, $noHidden, $noCounts, $optionalCounts, $noExists, $optionalExists, $optionalNullables, $fillables, $fillableSuffix, $useEnums) {
+        $models->each(function (SplFileInfo $model) use ($mappings, $modelBuilder, $colAttrWriter, $relationWriter, $countWriter, $existWriter, $sumWriter, $plurals, $apiResources, $optionalRelations, $noRelations, $noHidden, $noCounts, $optionalCounts, $noExists, $optionalExists, $noSums, $optionalSums, $optionalNullables, $fillables, $fillableSuffix, $useEnums) {
             $entry = '';
             $modelDetails = $modelBuilder(
                 modelFile: $model,
@@ -73,14 +72,15 @@ final class GenerateCliOutput
                 'relations' => $relations,
                 'interfaces' => $interfaces,
                 'imports' => $imports,
+                'sums' => $sums,
             ] = $modelDetails;
 
             $this->imports = array_merge($this->imports, $imports->toArray());
 
-            $entry .= "{$this->indent}export interface {$name} {".PHP_EOL;
+            $entry .= "{$this->indent}export interface {$name} {" . PHP_EOL;
 
             if ($columns->isNotEmpty()) {
-                $entry .= "{$this->indent}  // columns".PHP_EOL;
+                $entry .= "{$this->indent}  // columns" . PHP_EOL;
                 $columns->each(function ($att) use (&$entry, $reflectionModel, $colAttrWriter, $noHidden, $optionalNullables, $mappings, $useEnums) {
                     [$line, $enum] = $colAttrWriter(reflectionModel: $reflectionModel, attribute: $att, mappings: $mappings, indent: $this->indent, noHidden: $noHidden, optionalNullables: $optionalNullables, useEnums: $useEnums);
                     if (! empty($line)) {
@@ -93,7 +93,7 @@ final class GenerateCliOutput
             }
 
             if ($nonColumns->isNotEmpty()) {
-                $entry .= "{$this->indent}  // mutators".PHP_EOL;
+                $entry .= "{$this->indent}  // mutators" . PHP_EOL;
                 $nonColumns->each(function ($att) use (&$entry, $reflectionModel, $colAttrWriter, $noHidden, $optionalNullables, $mappings, $useEnums) {
                     [$line, $enum] = $colAttrWriter(reflectionModel: $reflectionModel, attribute: $att, mappings: $mappings, indent: $this->indent, noHidden: $noHidden, optionalNullables: $optionalNullables, useEnums: $useEnums);
                     if (! empty($line)) {
@@ -106,7 +106,7 @@ final class GenerateCliOutput
             }
 
             if ($interfaces->isNotEmpty()) {
-                $entry .= "{$this->indent}  // overrides".PHP_EOL;
+                $entry .= "{$this->indent}  // overrides" . PHP_EOL;
                 $interfaces->each(function ($interface) use (&$entry, $reflectionModel, $colAttrWriter, $mappings) {
                     [$line] = $colAttrWriter(reflectionModel: $reflectionModel, attribute: $interface, mappings: $mappings, indent: $this->indent);
                     $entry .= $line;
@@ -114,33 +114,54 @@ final class GenerateCliOutput
             }
 
             if ($relations->isNotEmpty() && ! $noRelations) {
-                $entry .= "{$this->indent}  // relations".PHP_EOL;
-                $relations->each(function ($rel) use (&$entry, $relationWriter, $optionalRelations, $noCounts, $optionalCounts, $noExists, $optionalExists, $plurals) {
-                    $entry .= $relationWriter(relation: $rel, indent: $this->indent, optionalRelation: $optionalRelations, noCounts: $noCounts, optionalCounts: $optionalCounts, noExists: $noExists, optionalExists: $optionalExists, plurals: $plurals);
+                $entry .= "{$this->indent}  // relations" . PHP_EOL;
+                $relations->each(function ($rel) use (&$entry, $relationWriter, $optionalRelations, $plurals) {
+                    $entry .= $relationWriter(relation: $rel, indent: $this->indent, optionalRelation: $optionalRelations, plurals: $plurals);
                 });
             }
 
-            $entry .= "{$this->indent}}".PHP_EOL;
+            if ($relations->isNotEmpty() && ! $noCounts) {
+                $entry .= "{$this->indent}  // counts" . PHP_EOL;
+                $relations->each(function ($rel) use (&$entry, $countWriter, $optionalCounts) {
+                    $entry .= $countWriter(relation: $rel, indent: $this->indent, optionalCounts: $optionalCounts);
+                });
+            }
+
+            if ($relations->isNotEmpty() && ! $noExists) {
+                $entry .= "{$this->indent}  // exists" . PHP_EOL;
+                $relations->each(function ($rel) use (&$entry, $existWriter, $optionalExists) {
+                    $entry .= $existWriter(relation: $rel, indent: $this->indent, optionalExists: $optionalExists);
+                });
+            }
+
+            if ($sums->isNotEmpty() && ! $noSums) {
+                $entry .= "{$this->indent}  // sums" . PHP_EOL;
+                $sums->each(function ($sum) use (&$entry, $sumWriter, $optionalSums) {
+                    $entry .= $sumWriter(sum: $sum, indent: $this->indent, optionalSums: $optionalSums);
+                });
+            }
+
+            $entry .= "{$this->indent}}" . PHP_EOL;
 
             if ($plurals) {
                 $plural = Str::plural($name);
-                $entry .= "{$this->indent}export type $plural = {$name}[]".PHP_EOL;
+                $entry .= "{$this->indent}export type $plural = {$name}[]" . PHP_EOL;
 
                 if ($apiResources) {
-                    $entry .= "{$this->indent}export interface {$name}Results extends api.MetApiResults { data: $plural }".PHP_EOL;
+                    $entry .= "{$this->indent}export interface {$name}Results extends api.MetApiResults { data: $plural }" . PHP_EOL;
                 }
             }
 
             if ($apiResources) {
-                $entry .= "{$this->indent}export interface {$name}Result extends api.MetApiResults { data: $name }".PHP_EOL;
-                $entry .= "{$this->indent}export interface {$name}MetApiData extends api.MetApiData { data: $name }".PHP_EOL;
-                $entry .= "{$this->indent}export interface {$name}Response extends api.MetApiResponse { data: {$name}MetApiData }".PHP_EOL;
+                $entry .= "{$this->indent}export interface {$name}Result extends api.MetApiResults { data: $name }" . PHP_EOL;
+                $entry .= "{$this->indent}export interface {$name}MetApiData extends api.MetApiData { data: $name }" . PHP_EOL;
+                $entry .= "{$this->indent}export interface {$name}Response extends api.MetApiResponse { data: {$name}MetApiData }" . PHP_EOL;
             }
 
             if ($fillables) {
                 $fillableAttributes = $reflectionModel->newInstanceWithoutConstructor()->getFillable();
                 $fillablesUnion = implode(' | ', array_map(fn ($fillableAttribute) => "'$fillableAttribute'", $fillableAttributes));
-                $entry .= "{$this->indent}export type {$name}{$fillableSuffix} = Pick<$name, $fillablesUnion>".PHP_EOL;
+                $entry .= "{$this->indent}export type {$name}{$fillableSuffix} = Pick<$name, $fillablesUnion>" . PHP_EOL;
             }
 
             $entry .= PHP_EOL;
@@ -158,14 +179,14 @@ final class GenerateCliOutput
             ->unique()
             ->each(function ($import) {
                 $importTypeWithoutGeneric = Str::before($import['type'], '<');
-                $entry = "import { {$importTypeWithoutGeneric} } from '{$import['import']}'".PHP_EOL;
-                $this->output = $entry.$this->output;
+                $entry = "import { {$importTypeWithoutGeneric} } from '{$import['import']}'" . PHP_EOL;
+                $this->output = $entry . $this->output;
             });
 
         if ($global) {
-            $this->output .= '  }'.PHP_EOL.'}'.PHP_EOL.PHP_EOL;
+            $this->output .= '  }' . PHP_EOL . '}' . PHP_EOL . PHP_EOL;
         }
 
-        return mb_substr($this->output, 0, mb_strrpos($this->output, PHP_EOL));
+        return substr($this->output, 0, strrpos($this->output, PHP_EOL));
     }
 }

--- a/src/Actions/GenerateJsonOutput.php
+++ b/src/Actions/GenerateJsonOutput.php
@@ -2,6 +2,8 @@
 
 namespace FumeApp\ModelTyper\Actions;
 
+use const JSON_PRETTY_PRINT;
+
 use FumeApp\ModelTyper\Traits\ClassBaseName;
 use FumeApp\ModelTyper\Traits\ModelRefClass;
 use Illuminate\Support\Collection;
@@ -9,7 +11,6 @@ use Illuminate\Support\Facades\Config;
 use ReflectionClass;
 use ReflectionException;
 use Symfony\Component\Finder\SplFileInfo;
-use const JSON_PRETTY_PRINT;
 
 class GenerateJsonOutput
 {
@@ -29,8 +30,9 @@ class GenerateJsonOutput
     /**
      * Output the command in the CLI as JSON.
      *
-     * @param Collection<int, SplFileInfo> $models
-     * @param array<string, string> $mappings
+     * @param  Collection<int, SplFileInfo>  $models
+     * @param  array<string, string>  $mappings
+     *
      * @throws ReflectionException
      */
     public function __invoke(Collection $models, array $mappings, bool $useEnums = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $noSums = false, bool $optionalSums = false): string

--- a/src/Actions/GenerateJsonOutput.php
+++ b/src/Actions/GenerateJsonOutput.php
@@ -1,10 +1,6 @@
 <?php
 
-declare(strict_types=1);
-
 namespace FumeApp\ModelTyper\Actions;
-
-use const JSON_PRETTY_PRINT;
 
 use FumeApp\ModelTyper\Traits\ClassBaseName;
 use FumeApp\ModelTyper\Traits\ModelRefClass;
@@ -13,12 +9,10 @@ use Illuminate\Support\Facades\Config;
 use ReflectionClass;
 use ReflectionException;
 use Symfony\Component\Finder\SplFileInfo;
+use const JSON_PRETTY_PRINT;
 
-final class GenerateJsonOutput
+class GenerateJsonOutput
 {
-    use ClassBaseName;
-    use ModelRefClass;
-
     /**
      * @var array<string, array<string, mixed>>
      */
@@ -29,22 +23,27 @@ final class GenerateJsonOutput
      */
     protected array $enumReflectors = [];
 
+    use ClassBaseName;
+    use ModelRefClass;
+
     /**
      * Output the command in the CLI as JSON.
      *
-     * @param  Collection<int, SplFileInfo>  $models
-     * @param  array<string, string>  $mappings
-     *
+     * @param Collection<int, SplFileInfo> $models
+     * @param array<string, string> $mappings
      * @throws ReflectionException
      */
-    public function __invoke(Collection $models, array $mappings, bool $useEnums = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false): string
+    public function __invoke(Collection $models, array $mappings, bool $useEnums = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $noSums = false, bool $optionalSums = false): string
     {
         $modelBuilder = app(BuildModelDetails::class);
         $colAttrWriter = app(WriteColumnAttribute::class);
         $relationWriter = app(WriteRelationship::class);
         $enumWriter = app(WriteEnumConst::class);
+        $countWriter = app(WriteCount::class);
+        $existWriter = app(WriteExist::class);
+        $sumWriter = app(WriteSum::class);
 
-        $models->each(function (SplFileInfo $model) use ($modelBuilder, $colAttrWriter, $relationWriter, $mappings, $useEnums, $noCounts, $optionalCounts, $noExists, $optionalExists) {
+        $models->each(function (SplFileInfo $model) use ($modelBuilder, $colAttrWriter, $relationWriter, $countWriter, $existWriter, $sumWriter, $mappings, $useEnums, $noCounts, $optionalCounts, $noExists, $optionalExists, $noSums, $optionalSums): void {
             $modelDetails = $modelBuilder(
                 modelFile: $model,
                 includedModels: Config::get('modeltyper.included_models', []),
@@ -63,13 +62,14 @@ final class GenerateJsonOutput
                 'nonColumns' => $nonColumns,
                 'relations' => $relations,
                 'interfaces' => $interfaces,
+                'sums' => $sums,
             ] = $modelDetails;
 
             $this->output['interfaces'][$name] = $columns
                 ->merge($nonColumns)
                 ->merge($interfaces)
                 ->map(function ($att) use ($reflectionModel, $colAttrWriter, $mappings, $useEnums) {
-                    [$property, $enum] = $colAttrWriter(reflectionModel: $reflectionModel, mappings: $mappings, attribute: $att, jsonOutput: true, useEnums: $useEnums);
+                    [$property, $enum] = $colAttrWriter(reflectionModel: $reflectionModel, attribute: $att, mappings: $mappings, jsonOutput: true, useEnums: $useEnums);
                     if ($enum) {
                         $this->enumReflectors[] = $enum;
                     }
@@ -77,13 +77,41 @@ final class GenerateJsonOutput
                     return $property;
                 })->toArray();
 
-            $this->output['relations'] = $relations->map(function ($rel) use ($relationWriter, $name, $noCounts, $optionalCounts, $noExists, $optionalExists) {
-                $relation = $relationWriter(relation: $rel, jsonOutput: true, noCounts: $noCounts, optionalCounts: $optionalCounts, noExists: $noExists, optionalExists: $optionalExists);
+            if (! $noCounts) {
+                $relations->each(function ($rel) use ($countWriter, $name, $optionalCounts) {
+                    $countConst = $countWriter(relation: $rel, jsonOutput: true, optionalCounts: $optionalCounts);
+
+                    if (! empty($countConst)) {
+                        $this->output['interfaces'][$name][] = $countConst;
+                    }
+                });
+            }
+
+            if (! $noExists) {
+                $relations->each(function ($rel) use ($existWriter, $name, $optionalExists) {
+                    $existConst = $existWriter(relation: $rel, jsonOutput: true, optionalExists: $optionalExists);
+
+                    if (! empty($existConst)) {
+                        $this->output['interfaces'][$name][] = $existConst;
+                    }
+                });
+            }
+
+            if (! $noSums) {
+                $sums->each(function ($sum) use ($sumWriter, $name, $optionalSums) {
+                    $sumConst = $sumWriter(sum: $sum, jsonOutput: true, optionalSums: $optionalSums);
+
+                    $this->output['interfaces'][$name][] = $sumConst;
+                });
+            }
+
+            $this->output['relations'] = $relations->map(function ($rel) use ($relationWriter, $name) {
+                $relation = $relationWriter(relation: $rel, jsonOutput: true);
 
                 return [
                     $relation['type'] => [
                         'name' => $relation['name'],
-                        'type' => 'export type '.$relation['type'].' = '.'Array<'.$name.'>',
+                        'type' => 'export type ' . $relation['type'] . ' = ' . 'Array<' . $name . '>',
                     ],
                 ];
             })->toArray();
@@ -100,6 +128,6 @@ final class GenerateJsonOutput
             ];
         })->toArray();
 
-        return json_encode($this->output, JSON_PRETTY_PRINT).PHP_EOL;
+        return json_encode($this->output, JSON_PRETTY_PRINT) . PHP_EOL;
     }
 }

--- a/src/Actions/Generator.php
+++ b/src/Actions/Generator.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace FumeApp\ModelTyper\Actions;
 
 use FumeApp\ModelTyper\Exceptions\ModelTyperException;
@@ -13,14 +11,35 @@ use Symfony\Component\Finder\SplFileInfo;
 /**
  * @throws ModelTyperException
  */
-final class Generator
+class Generator
 {
     /**
      * Run the command to generate the output.
      *
+     * @param string|null $specificModel
+     * @param bool $global
+     * @param bool $json
+     * @param bool $useEnums
+     * @param bool $plurals
+     * @param bool $apiResources
+     * @param bool $optionalRelations
+     * @param bool $noRelations
+     * @param bool $noHidden
+     * @param bool $noCounts
+     * @param bool $optionalCounts
+     * @param bool $noExists
+     * @param bool $optionalExists
+     * @param bool $noSums
+     * @param bool $optionalSums
+     * @param bool $timestampsDate
+     * @param bool $optionalNullables
+     * @param bool $fillables
+     * @param string $fillableSuffix
+     * @return string
      * @throws ModelTyperException
+     * @throws ReflectionException
      */
-    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $noCounts = false, bool $optionalCounts = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
+    public function __invoke(?string $specificModel = null, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $noSums = false, bool $optionalSums = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
     {
         $models = app(GetModels::class)(
             model: $specificModel,
@@ -44,6 +63,10 @@ final class Generator
             noHidden: $noHidden,
             noCounts: $noCounts,
             optionalCounts: $optionalCounts,
+            noExists: $noExists,
+            optionalExists: $optionalExists,
+            noSums: $noSums,
+            optionalSums: $optionalSums,
             timestampsDate: $timestampsDate,
             optionalNullables: $optionalNullables,
             fillables: $fillables,
@@ -54,16 +77,34 @@ final class Generator
     /**
      * Return the command output.
      *
-     * @param  Collection<int, SplFileInfo>  $models
-     *
+     * @param Collection<int, SplFileInfo> $models
+     * @param bool $global
+     * @param bool $json
+     * @param bool $useEnums
+     * @param bool $plurals
+     * @param bool $apiResources
+     * @param bool $optionalRelations
+     * @param bool $noRelations
+     * @param bool $noHidden
+     * @param bool $noCounts
+     * @param bool $optionalCounts
+     * @param bool $noExists
+     * @param bool $optionalExists
+     * @param bool $noSums
+     * @param bool $optionalSums
+     * @param bool $timestampsDate
+     * @param bool $optionalNullables
+     * @param bool $fillables
+     * @param string $fillableSuffix
+     * @return string
      * @throws ReflectionException
      */
-    private function display(Collection $models, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
+    protected function display(Collection $models, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $noSums = false, bool $optionalSums = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string
     {
         $mappings = app(GetMappings::class)(setTimestampsToDate: $timestampsDate);
 
         if ($json) {
-            return app(GenerateJsonOutput::class)(models: $models, mappings: $mappings, useEnums: $useEnums, noCounts: $noCounts, optionalCounts: $optionalCounts, noExists: $noExists, optionalExists: $optionalExists);
+            return app(GenerateJsonOutput::class)(models: $models, mappings: $mappings, useEnums: $useEnums, noCounts: $noCounts, optionalCounts: $optionalCounts, noExists: $noExists, optionalExists: $optionalExists, noSums: $noSums, optionalSums: $optionalSums);
         }
 
         return app(GenerateCliOutput::class)(
@@ -78,6 +119,10 @@ final class Generator
             noHidden: $noHidden,
             noCounts: $noCounts,
             optionalCounts: $optionalCounts,
+            noExists: $noExists,
+            optionalExists: $optionalExists,
+            noSums: $noSums,
+            optionalSums: $optionalSums,
             optionalNullables: $optionalNullables,
             fillables: $fillables,
             fillableSuffix: $fillableSuffix

--- a/src/Actions/Generator.php
+++ b/src/Actions/Generator.php
@@ -16,26 +16,6 @@ class Generator
     /**
      * Run the command to generate the output.
      *
-     * @param string|null $specificModel
-     * @param bool $global
-     * @param bool $json
-     * @param bool $useEnums
-     * @param bool $plurals
-     * @param bool $apiResources
-     * @param bool $optionalRelations
-     * @param bool $noRelations
-     * @param bool $noHidden
-     * @param bool $noCounts
-     * @param bool $optionalCounts
-     * @param bool $noExists
-     * @param bool $optionalExists
-     * @param bool $noSums
-     * @param bool $optionalSums
-     * @param bool $timestampsDate
-     * @param bool $optionalNullables
-     * @param bool $fillables
-     * @param string $fillableSuffix
-     * @return string
      * @throws ModelTyperException
      * @throws ReflectionException
      */
@@ -77,26 +57,8 @@ class Generator
     /**
      * Return the command output.
      *
-     * @param Collection<int, SplFileInfo> $models
-     * @param bool $global
-     * @param bool $json
-     * @param bool $useEnums
-     * @param bool $plurals
-     * @param bool $apiResources
-     * @param bool $optionalRelations
-     * @param bool $noRelations
-     * @param bool $noHidden
-     * @param bool $noCounts
-     * @param bool $optionalCounts
-     * @param bool $noExists
-     * @param bool $optionalExists
-     * @param bool $noSums
-     * @param bool $optionalSums
-     * @param bool $timestampsDate
-     * @param bool $optionalNullables
-     * @param bool $fillables
-     * @param string $fillableSuffix
-     * @return string
+     * @param  Collection<int, SplFileInfo>  $models
+     *
      * @throws ReflectionException
      */
     protected function display(Collection $models, bool $global = false, bool $json = false, bool $useEnums = false, bool $plurals = false, bool $apiResources = false, bool $optionalRelations = false, bool $noRelations = false, bool $noHidden = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $noSums = false, bool $optionalSums = false, bool $timestampsDate = false, bool $optionalNullables = false, bool $fillables = false, string $fillableSuffix = 'Fillable'): string

--- a/src/Actions/WriteCount.php
+++ b/src/Actions/WriteCount.php
@@ -3,7 +3,6 @@
 namespace FumeApp\ModelTyper\Actions;
 
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Str;
 
 class WriteCount
 {

--- a/src/Actions/WriteCount.php
+++ b/src/Actions/WriteCount.php
@@ -26,12 +26,7 @@ class WriteCount
             'MorphToMany', 'MorphMany', 'MorphedByMany',
         ]);
 
-        $countName = match ($columnsCase) {
-            'camel' => Str::camel("{$name}Count"),
-            'pascal' => Str::studly("{$name}Count"),
-            'kebab' => Str::kebab("{$name}-count"),
-            default => "{$name}_count",
-        };
+        $countName = app(MatchCase::class)($columnsCase, "$name count");
 
         if ($jsonOutput) {
             if ($isCountable) {

--- a/src/Actions/WriteCount.php
+++ b/src/Actions/WriteCount.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace FumeApp\ModelTyper\Actions;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+
+class WriteCount
+{
+    /**
+     * Write the relationship counts to the output.
+     *
+     * @param  array{name: string, type: string, related:string}  $relation
+     * @return array{type: string, name: string}|string
+     */
+    public function __invoke(array $relation, string $indent = '', bool $jsonOutput = false, bool $optionalCounts = false): array|string
+    {
+        $relationCase = Config::get('modeltyper.case.relations', 'snake');
+        $columnsCase = Config::get('modeltyper.case.columns', 'snake');
+        $name = app(MatchCase::class)($relationCase, $relation['name']);
+
+        $optional = $optionalCounts ? '?' : '';
+
+        $isCountable = in_array($relation['type'], [
+            'BelongsToMany', 'HasMany', 'HasManyThrough',
+            'MorphToMany', 'MorphMany', 'MorphedByMany',
+        ]);
+
+        $countName = match ($columnsCase) {
+            'camel' => Str::camel("{$name}Count"),
+            'pascal' => Str::studly("{$name}Count"),
+            'kebab' => Str::kebab("{$name}-count"),
+            default => "{$name}_count",
+        };
+
+        if ($jsonOutput) {
+            if ($isCountable) {
+                return [
+                    'name' => "{$countName}{$optional}",
+                    'type' => 'number',
+                ];
+            }
+        }
+
+        if ($isCountable) {
+            return "{$indent}  {$countName}{$optional}: number" . PHP_EOL;
+        }
+
+        return "";
+    }
+}

--- a/src/Actions/WriteCount.php
+++ b/src/Actions/WriteCount.php
@@ -46,6 +46,6 @@ class WriteCount
             return "{$indent}  {$countName}{$optional}: number" . PHP_EOL;
         }
 
-        return "";
+        return '';
     }
 }

--- a/src/Actions/WriteExist.php
+++ b/src/Actions/WriteExist.php
@@ -4,7 +4,6 @@ namespace FumeApp\ModelTyper\Actions;
 
 use FumeApp\ModelTyper\Traits\ClassBaseName;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Str;
 
 class WriteExist
 {

--- a/src/Actions/WriteExist.php
+++ b/src/Actions/WriteExist.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace FumeApp\ModelTyper\Actions;
+
+use FumeApp\ModelTyper\Traits\ClassBaseName;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+
+class WriteExist
+{
+    use ClassBaseName;
+
+    /**
+     * Write the relationship exists field to the output.
+     *
+     * @param  array{name: string, type: string, related:string}  $relation
+     * @return array{type: string, name: string}|string
+     */
+    public function __invoke(array $relation, string $indent = '', bool $jsonOutput = false, bool $noExists = false, bool $optionalExists = false): array|string
+    {
+        $relationCase = Config::get('modeltyper.case.relations', 'snake');
+        $columnsCase = Config::get('modeltyper.case.columns', 'snake');
+        $name = app(MatchCase::class)($relationCase, $relation['name']);
+
+        $relatedModel = $this->getClassName($relation['related']);
+        $optional = $optionalExists ? '?' : '';
+
+        $isExistable = in_array($relation['type'], [
+            'BelongsToMany', 'HasMany', 'HasManyThrough',
+            'MorphToMany', 'MorphMany', 'MorphedByMany',
+        ]);
+
+        $existsName = match ($columnsCase) {
+            'camel' => Str::camel("{$name}Exists"),
+            'pascal' => Str::studly("{$name}Exists"),
+            'kebab' => Str::kebab("{$name}-exists"),
+            default => "{$name}_exists",
+        };
+
+        $shouldAddExists = !$noExists && $isExistable;
+
+        if ($jsonOutput) {
+            if ($shouldAddExists) {
+                return [
+                    'name' => "{$existsName}{$optional}",
+                    'type' => 'boolean',
+                ];
+            }
+        }
+
+        if ($shouldAddExists) {
+            return "{$indent}  {$existsName}{$optional}: boolean" . PHP_EOL;
+        }
+
+        return "";
+    }
+}

--- a/src/Actions/WriteExist.php
+++ b/src/Actions/WriteExist.php
@@ -22,20 +22,21 @@ class WriteExist
         $columnsCase = Config::get('modeltyper.case.columns', 'snake');
         $name = app(MatchCase::class)($relationCase, $relation['name']);
 
-        $relatedModel = $this->getClassName($relation['related']);
         $optional = $optionalExists ? '?' : '';
 
         $isExistable = in_array($relation['type'], [
-            'BelongsToMany', 'HasMany', 'HasManyThrough',
-            'MorphToMany', 'MorphMany', 'MorphedByMany',
+            'HasOne',
+            'HasMany',
+            'HasOneThrough',
+            'HasManyThrough',
+            'BelongsTo',
+            'BelongsToMany',
+            'MorphOne',
+            'MorphMany',
+            'MorphToMany',
         ]);
 
-        $existsName = match ($columnsCase) {
-            'camel' => Str::camel("{$name}Exists"),
-            'pascal' => Str::studly("{$name}Exists"),
-            'kebab' => Str::kebab("{$name}-exists"),
-            default => "{$name}_exists",
-        };
+        $existsName = app(MatchCase::class)($columnsCase, "{$name} exists");
 
         $shouldAddExists = ! $noExists && $isExistable;
 

--- a/src/Actions/WriteExist.php
+++ b/src/Actions/WriteExist.php
@@ -37,7 +37,7 @@ class WriteExist
             default => "{$name}_exists",
         };
 
-        $shouldAddExists = !$noExists && $isExistable;
+        $shouldAddExists = ! $noExists && $isExistable;
 
         if ($jsonOutput) {
             if ($shouldAddExists) {
@@ -52,6 +52,6 @@ class WriteExist
             return "{$indent}  {$existsName}{$optional}: boolean" . PHP_EOL;
         }
 
-        return "";
+        return '';
     }
 }

--- a/src/Actions/WriteRelationship.php
+++ b/src/Actions/WriteRelationship.php
@@ -16,111 +16,35 @@ class WriteRelationship
      * @param  array{name: string, type: string, related:string}  $relation
      * @return array{type: string, name: string}|string
      */
-    public function __invoke(array $relation, string $indent = '', bool $jsonOutput = false, bool $optionalRelation = false, bool $noCounts = false, bool $optionalCounts = false, bool $noExists = false, bool $optionalExists = false, bool $plurals = false): array|string
+    public function __invoke(array $relation, string $indent = '', bool $jsonOutput = false, bool $optionalRelation = false, bool $plurals = false): array|string
     {
-        $relationCase = Config::get('modeltyper.case.relations', 'snake');
-        $columnsCase = Config::get('modeltyper.case.columns', 'snake');
-        $name = app(MatchCase::class)($relationCase, $relation['name']);
+        $case = Config::get('modeltyper.case.relations', 'snake');
+        $name = app(MatchCase::class)($case, $relation['name']);
 
         $relatedModel = $this->getClassName($relation['related']);
         $optional = $optionalRelation ? '?' : '';
 
-        // Use config if not explicitly provided
-        $noCounts = $noCounts ?? Config::get('modeltyper.no-counts', false);
-        $optionalCounts = $optionalCounts ?? Config::get('modeltyper.optional-counts', false);
-        $noExists = $noExists ?? Config::get('modeltyper.no-exists', false);
-        $optionalExists = $optionalExists ?? Config::get('modeltyper.optional-exists', false);
-
-        // Determine if this is a countable relation
-        $isCountable = in_array($relation['type'], [
-            'BelongsToMany', 'HasMany', 'HasManyThrough',
-            'MorphToMany', 'MorphMany', 'MorphedByMany',
-        ]);
-
-        // Handle no-counts option
-        if ($noCounts && $isCountable) {
-            $relationType = Str::singular($relatedModel);
-            $shouldAddCount = false;
-        } else {
-            $relationType = match ($relation['type']) {
-                'BelongsToMany', 'HasMany', 'HasManyThrough', 'MorphToMany', 'MorphMany', 'MorphedByMany' => $plurals === true ? Str::plural($relatedModel) : (Str::singular($relatedModel) . '[]'),
-                'BelongsTo', 'HasOne', 'HasOneThrough', 'MorphOne', 'MorphTo' => Str::singular($relatedModel),
-                default => $relatedModel,
-            };
-            $shouldAddCount = $isCountable;
-        }
-
-        // Handle optional-counts option
-        if ($optionalCounts && $isCountable && ! $noCounts) {
-            $optional = '?';
-        }
+        $relationType = match ($relation['type']) {
+            'BelongsToMany', 'HasMany', 'HasManyThrough', 'MorphToMany', 'MorphMany', 'MorphedByMany' => $plurals === true ? Str::plural($relatedModel) : (Str::singular($relatedModel) . '[]'),
+            'BelongsTo', 'HasOne', 'HasOneThrough', 'MorphOne', 'MorphTo' => Str::singular($relatedModel),
+            default => $relatedModel,
+        };
 
         if (in_array($relation['type'], Config::get('modeltyper.custom_relationships.singular', []))) {
             $relationType = Str::singular($relation['type']);
-            $shouldAddCount = false;
         }
 
         if (in_array($relation['type'], Config::get('modeltyper.custom_relationships.plural', []))) {
             $relationType = Str::singular($relation['type']);
-            $shouldAddCount = false;
         }
 
-        $countName = match ($columnsCase) {
-            'camel' => Str::camel("{$name}Count"),
-            'pascal' => Str::studly("{$name}Count"),
-            'kebab' => Str::kebab("{$name}-count"),
-            default => "{$name}_count",
-        };
-
-        $existsName = match ($columnsCase) {
-            'camel' => Str::camel("{$name}Exists"),
-            'pascal' => Str::studly("{$name}Exists"),
-            'kebab' => Str::kebab("{$name}-exists"),
-            default => "{$name}_exists",
-        };
-
-        // Determine if we should add exists field
-        $shouldAddExists = ! $noExists && $isCountable;
-        $optionalCounts = $optionalCounts ? '?' : '';
-        $existsOptional = $optionalExists ? '?' : '';
-
         if ($jsonOutput) {
-            $result = [
+            return [
                 'name' => "{$name}{$optional}",
                 'type' => $relationType,
             ];
-
-            // Add count field for countable relationships
-            if ($shouldAddCount) {
-                $result['count'] = [
-                    'name' => "{$countName}{$optionalCounts}",
-                    'type' => 'number',
-                ];
-            }
-
-            // Add exists field for countable relationships
-            if ($shouldAddExists) {
-                $result['exists'] = [
-                    'name' => "{$existsName}{$existsOptional}",
-                    'type' => 'boolean',
-                ];
-            }
-
-            return $result;
         }
 
-        $output = "{$indent}  {$name}{$optional}: {$relationType}" . PHP_EOL;
-
-        // Add count field for countable relationships
-        if ($shouldAddCount) {
-            $output .= "{$indent}  {$countName}{$optionalCounts}: number" . PHP_EOL;
-        }
-
-        // Add exists field for countable relationships
-        if ($shouldAddExists) {
-            $output .= "{$indent}  {$existsName}{$existsOptional}: boolean" . PHP_EOL;
-        }
-
-        return $output;
+        return "{$indent}  {$name}{$optional}: {$relationType}" . PHP_EOL;
     }
 }

--- a/src/Actions/WriteSum.php
+++ b/src/Actions/WriteSum.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace FumeApp\ModelTyper\Actions;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+
+class WriteSum
+{
+    public function __invoke(array $sum, string $indent = '', bool $jsonOutput = false, bool $optionalSums = false): string|array
+    {
+        $relation = $sum['relation'];
+        $column = $sum['column'];
+
+        $columnsCase = Config::get('modeltyper.case.columns', 'snake');
+        $optionalSums = $optionalSums ? '?' : '';
+
+        $sumName = match ($columnsCase) {
+            'camel' => Str::camel("{$relation}_sum_{$column}"),
+            'pascal' => Str::studly("{$relation}_sum_{$column}"),
+            'kebab' => Str::kebab("{$relation}_sum_{$column}"),
+            default => "{$relation}_sum_{$column}",
+        };
+
+        if ($jsonOutput) {
+            return [
+                'type' => 'number | null',
+                'name' => "{$sumName}{$optionalSums}",
+            ];
+        }
+
+        return "{$indent}  {$sumName}{$optionalSums}: number | null;" . PHP_EOL;
+    }
+}

--- a/src/Actions/WriteSum.php
+++ b/src/Actions/WriteSum.php
@@ -12,23 +12,18 @@ class WriteSum
         $relation = $sum['relation'];
         $column = $sum['column'];
 
-        $columnsCase = Config::get('modeltyper.case.columns', 'snake');
-        $optionalSums = $optionalSums ? '?' : '';
+        $case = Config::get('modeltyper.case.columns', 'snake');
+        $optional = $optionalSums ? '?' : '';
 
-        $sumName = match ($columnsCase) {
-            'camel' => Str::camel("{$relation}_sum_{$column}"),
-            'pascal' => Str::studly("{$relation}_sum_{$column}"),
-            'kebab' => Str::kebab("{$relation}_sum_{$column}"),
-            default => "{$relation}_sum_{$column}",
-        };
+        $sumName = app(MatchCase::class)($case, "{$relation} sum {$column}");
 
         if ($jsonOutput) {
             return [
                 'type' => 'number | null',
-                'name' => "{$sumName}{$optionalSums}",
+                'name' => "{$sumName}{$optional}",
             ];
         }
 
-        return "{$indent}  {$sumName}{$optionalSums}: number | null;" . PHP_EOL;
+        return "{$indent}  {$sumName}{$optional}: number | null;" . PHP_EOL;
     }
 }

--- a/src/Actions/WriteSum.php
+++ b/src/Actions/WriteSum.php
@@ -3,7 +3,6 @@
 namespace FumeApp\ModelTyper\Actions;
 
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Str;
 
 class WriteSum
 {

--- a/src/Commands/ModelTyperCommand.php
+++ b/src/Commands/ModelTyperCommand.php
@@ -7,7 +7,9 @@ use FumeApp\ModelTyper\Exceptions\ModelTyperException;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Config;
+use ReflectionException;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command as CommandAlias;
 
 #[AsCommand(name: 'model:typer')]
 class ModelTyperCommand extends Command
@@ -36,6 +38,10 @@ class ModelTyperCommand extends Command
                             {--no-hidden : Do not include hidden model attributes}
                             {--no-counts : Do not include counts on relations}
                             {--optional-counts : Make counts on relations optional fields}
+                            {--no-exists : Do not include exists on relations}
+                            {--optional-exists : Make exists on relations optional fields}
+                            {--no-sums : Do not include sums on relations}
+                            {--optional-sums : Make sums on relations optional fields}
                             {--timestamps-date : Output timestamps as a Date object type}
                             {--optional-nullables : Output nullable attributes as optional fields}
                             {--api-resources : Output api.MetApi interfaces}
@@ -60,6 +66,7 @@ class ModelTyperCommand extends Command
 
     /**
      * Execute the console command.
+     * @throws ReflectionException
      */
     public function handle(Generator $generator): int
     {
@@ -76,6 +83,10 @@ class ModelTyperCommand extends Command
                 noHidden: $this->getConfig('no-hidden'),
                 noCounts: $this->getConfig('no-counts'),
                 optionalCounts: $this->getConfig('optional-counts'),
+                noExists: $this->getConfig('no-exists'),
+                optionalExists: $this->getConfig('optional-exists'),
+                noSums: $this->getConfig('no-sums'),
+                optionalSums: $this->getConfig('optional-sums'),
                 timestampsDate: $this->getConfig('timestamps-date'),
                 optionalNullables: $this->getConfig('optional-nullables'),
                 fillables: $this->getConfig('fillables'),
@@ -89,23 +100,23 @@ class ModelTyperCommand extends Command
                 $path = (string) Config::get('modeltyper.output-file-path', '');
             }
 
-            if (! is_null($path) && strlen($path) > 0) {
+            if (! is_null($path) && mb_strlen($path) > 0) {
                 $this->files->ensureDirectoryExists(dirname($path));
                 $this->files->put($path, $output);
 
                 $this->info('Typescript interfaces generated in ' . $path . ' file');
 
-                return Command::SUCCESS;
+                return CommandAlias::SUCCESS;
             }
 
             $this->line($output);
         } catch (ModelTyperException $exception) {
             $this->error($exception->getMessage());
 
-            return Command::FAILURE;
+            return CommandAlias::FAILURE;
         }
 
-        return Command::SUCCESS;
+        return CommandAlias::SUCCESS;
     }
 
     private function getConfig(string $key): string|bool

--- a/src/Commands/ModelTyperCommand.php
+++ b/src/Commands/ModelTyperCommand.php
@@ -66,6 +66,7 @@ class ModelTyperCommand extends Command
 
     /**
      * Execute the console command.
+     *
      * @throws ReflectionException
      */
     public function handle(Generator $generator): int

--- a/src/Traits/ModelRefClass.php
+++ b/src/Traits/ModelRefClass.php
@@ -2,6 +2,9 @@
 
 namespace FumeApp\ModelTyper\Traits;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use ReflectionClass;
 
 trait ModelRefClass
@@ -9,8 +12,8 @@ trait ModelRefClass
     /**
      * Get the reflection interface.
      *
-     * @param  array{"class": class-string<\Illuminate\Database\Eloquent\Model>, database: string, table: string, policy: class-string|null, attributes: \Illuminate\Support\Collection, relations: \Illuminate\Support\Collection, events: \Illuminate\Support\Collection, observers: \Illuminate\Support\Collection, collection: class-string<\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>>, builder: class-string<\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>>}  $info
-     * @return \ReflectionClass<\Illuminate\Database\Eloquent\Model>
+     * @param  array{"class": class-string<Model>, database: string, table: string, policy: class-string|null, attributes: Collection, relations: Collection, events: Collection, observers: Collection, collection: class-string<\Illuminate\Database\Eloquent\Collection<Model>>, builder: class-string<Builder<Model>>}  $info
+     * @return ReflectionClass<Model>
      */
     public function getRefInterface(array $info): ReflectionClass
     {

--- a/test/Tests/Feature/Actions/WriteCountTest.php
+++ b/test/Tests/Feature/Actions/WriteCountTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\Actions;
+
+use FumeApp\ModelTyper\Actions\WriteCount;
+use Tests\TestCase;
+
+class WriteCountTest extends TestCase {
+    protected array $relation = [
+        'name' => 'notifications',
+        'type' => 'HasMany',
+        'related' => "Illuminate\Notifications\DatabaseNotification",
+    ];
+
+    public function test_action_can_be_resolved_by_application() {
+        $this->assertInstanceOf(WriteCount::class, resolve(WriteCount::class));
+    }
+
+    public function test_action_can_be_executed() {
+        $action = app(WriteCount::class);
+        $result = $action($this->relation);
+
+        $this->assertIsString($result);
+
+        $this->assertStringContainsString('notifications_count: number', $result);
+    }
+
+    public function test_action_can_return_array() {
+        $action = app(WriteCount::class);
+        $result = $action($this->relation, jsonOutput: true);
+
+        $this->assertIsArray($result);
+
+        $this->assertEquals([
+            'name' => 'notifications_count',
+            'type' => 'number',
+        ], $result);
+    }
+
+    public function test_action_can_be_indented() {
+        $action = app(WriteCount::class);
+        $result = $action($this->relation, indent: 'ASDF');
+
+        $this->assertStringContainsString('ASDF  notifications_count: number', $result);
+    }
+
+    public function test_action_can_return_optional_counts() {
+        $action = app(WriteCount::class);
+        $result = $action($this->relation, optionalCounts: true);
+
+        $this->assertStringContainsString('notifications_count?: number', $result);
+    }
+
+    public function test_action_can_return_optional_counts_with_pascal_case() {
+        config(['modeltyper.case.columns' => 'pascal']);
+        $action = app(WriteCount::class);
+        $result = $action($this->relation, optionalCounts: true);
+
+        $this->assertStringContainsString('NotificationsCount?: number', $result);
+    }
+
+    public function test_action_can_return_optional_counts_as_array() {
+        $action = app(WriteCount::class);
+        $result = $action($this->relation, jsonOutput: true, optionalCounts: true);
+
+        $this->assertEquals([
+            'name' => 'notifications_count?',
+            'type' => 'number',
+        ], $result);
+    }
+
+    public function test_action_returns_empty_string_for_non_countable_relation() {
+        $relation = [
+            'name' => 'user',
+            'type' => 'BelongsTo',
+            'related' => 'App\Models\User',
+        ];
+
+        $action = app(WriteCount::class);
+        $result = $action($relation);
+
+        $this->assertSame('', $result);
+    }
+}

--- a/test/Tests/Feature/Actions/WriteCountTest.php
+++ b/test/Tests/Feature/Actions/WriteCountTest.php
@@ -5,18 +5,21 @@ namespace Tests\Feature\Actions;
 use FumeApp\ModelTyper\Actions\WriteCount;
 use Tests\TestCase;
 
-class WriteCountTest extends TestCase {
+class WriteCountTest extends TestCase
+{
     protected array $relation = [
         'name' => 'notifications',
         'type' => 'HasMany',
         'related' => "Illuminate\Notifications\DatabaseNotification",
     ];
 
-    public function test_action_can_be_resolved_by_application() {
+    public function test_action_can_be_resolved_by_application()
+    {
         $this->assertInstanceOf(WriteCount::class, resolve(WriteCount::class));
     }
 
-    public function test_action_can_be_executed() {
+    public function test_action_can_be_executed()
+    {
         $action = app(WriteCount::class);
         $result = $action($this->relation);
 
@@ -25,7 +28,8 @@ class WriteCountTest extends TestCase {
         $this->assertStringContainsString('notifications_count: number', $result);
     }
 
-    public function test_action_can_return_array() {
+    public function test_action_can_return_array()
+    {
         $action = app(WriteCount::class);
         $result = $action($this->relation, jsonOutput: true);
 
@@ -37,21 +41,24 @@ class WriteCountTest extends TestCase {
         ], $result);
     }
 
-    public function test_action_can_be_indented() {
+    public function test_action_can_be_indented()
+    {
         $action = app(WriteCount::class);
         $result = $action($this->relation, indent: 'ASDF');
 
         $this->assertStringContainsString('ASDF  notifications_count: number', $result);
     }
 
-    public function test_action_can_return_optional_counts() {
+    public function test_action_can_return_optional_counts()
+    {
         $action = app(WriteCount::class);
         $result = $action($this->relation, optionalCounts: true);
 
         $this->assertStringContainsString('notifications_count?: number', $result);
     }
 
-    public function test_action_can_return_optional_counts_with_pascal_case() {
+    public function test_action_can_return_optional_counts_with_pascal_case()
+    {
         config(['modeltyper.case.columns' => 'pascal']);
         $action = app(WriteCount::class);
         $result = $action($this->relation, optionalCounts: true);
@@ -59,7 +66,8 @@ class WriteCountTest extends TestCase {
         $this->assertStringContainsString('NotificationsCount?: number', $result);
     }
 
-    public function test_action_can_return_optional_counts_as_array() {
+    public function test_action_can_return_optional_counts_as_array()
+    {
         $action = app(WriteCount::class);
         $result = $action($this->relation, jsonOutput: true, optionalCounts: true);
 
@@ -69,7 +77,8 @@ class WriteCountTest extends TestCase {
         ], $result);
     }
 
-    public function test_action_returns_empty_string_for_non_countable_relation() {
+    public function test_action_returns_empty_string_for_non_countable_relation()
+    {
         $relation = [
             'name' => 'user',
             'type' => 'BelongsTo',

--- a/test/Tests/Feature/Actions/WriteExistTest.php
+++ b/test/Tests/Feature/Actions/WriteExistTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\Actions;
+
+use FumeApp\ModelTyper\Actions\WriteExist;
+use Tests\TestCase;
+
+class WriteExistTest extends TestCase {
+    protected array $relation = [
+        'name' => 'notifications',
+        'type' => 'HasMany',
+        'related' => "Illuminate\Notifications\DatabaseNotification",
+    ];
+
+    public function test_action_can_be_resolved_by_application() {
+        $this->assertInstanceOf(WriteExist::class, resolve(WriteExist::class));
+    }
+
+    public function test_action_can_be_executed() {
+        $action = app(WriteExist::class);
+        $result = $action($this->relation);
+
+        $this->assertIsString($result);
+        $this->assertStringContainsString('notifications_exists: boolean', $result);
+    }
+
+    public function test_action_can_return_array() {
+        $action = app(WriteExist::class);
+        $result = $action($this->relation, jsonOutput: true);
+
+        $this->assertIsArray($result);
+        $this->assertEquals([
+            'name' => 'notifications_exists',
+            'type' => 'boolean',
+        ], $result);
+    }
+
+    public function test_action_can_be_indented() {
+        $action = app(WriteExist::class);
+        $result = $action($this->relation, indent: 'ASDF');
+
+        $this->assertStringContainsString('ASDF  notifications_exists: boolean', $result);
+    }
+
+    public function test_action_can_return_optional_exists() {
+        $action = app(WriteExist::class);
+        $result = $action($this->relation, optionalExists: true);
+
+        $this->assertStringContainsString('notifications_exists?: boolean', $result);
+    }
+    public function test_action_can_return_optional_exists_with_pascal_case() {
+        config(['modeltyper.case.columns' => 'pascal']);
+        $action = app(WriteExist::class);
+        $result = $action($this->relation, optionalExists: true);
+
+        $this->assertStringContainsString('NotificationsExists?: boolean', $result);
+    }
+
+    public function test_action_can_return_optional_exists_with_camel_case() {
+        config(['modeltyper.case.columns' => 'camel']);
+        $action = app(WriteExist::class);
+        $result = $action($this->relation, optionalExists: true);
+
+        $this->assertStringContainsString('notificationsExists?: boolean', $result);
+    }
+
+    public function test_action_can_return_optional_exists_as_array() {
+        $action = app(WriteExist::class);
+        $result = $action($this->relation, jsonOutput: true, optionalExists: true);
+
+        $this->assertEquals([
+            'name' => 'notifications_exists?',
+            'type' => 'boolean',
+        ], $result);
+    }
+
+    public function test_action_can_return_optional_exists_as_array_with_pascal_case() {
+        config(['modeltyper.case.columns' => 'pascal']);
+        $action = app(WriteExist::class);
+        $result = $action($this->relation, jsonOutput: true, optionalExists: true);
+
+        $this->assertEquals([
+            'name' => 'NotificationsExists?',
+            'type' => 'boolean',
+        ], $result);
+    }
+
+    public function test_action_can_return_optional_exists_as_array_with_camel_case() {
+        config(['modeltyper.case.columns' => 'camel']);
+        $action = app(WriteExist::class);
+        $result = $action($this->relation, jsonOutput: true, optionalExists: true);
+
+        $this->assertEquals([
+            'name' => 'notificationsExists?',
+            'type' => 'boolean',
+        ], $result);
+    }
+
+    public function test_action_returns_empty_string_for_non_existable_relation() {
+        $relation = [
+            'name' => 'users',
+            'type' => 'MorphedByMany',
+            'related' => 'App\Models\User',
+        ];
+
+        $action = app(WriteExist::class);
+        $result = $action($relation);
+
+        $this->assertSame('', $result);
+    }
+}

--- a/test/Tests/Feature/Actions/WriteExistTest.php
+++ b/test/Tests/Feature/Actions/WriteExistTest.php
@@ -5,18 +5,21 @@ namespace Tests\Feature\Actions;
 use FumeApp\ModelTyper\Actions\WriteExist;
 use Tests\TestCase;
 
-class WriteExistTest extends TestCase {
+class WriteExistTest extends TestCase
+{
     protected array $relation = [
         'name' => 'notifications',
         'type' => 'HasMany',
         'related' => "Illuminate\Notifications\DatabaseNotification",
     ];
 
-    public function test_action_can_be_resolved_by_application() {
+    public function test_action_can_be_resolved_by_application()
+    {
         $this->assertInstanceOf(WriteExist::class, resolve(WriteExist::class));
     }
 
-    public function test_action_can_be_executed() {
+    public function test_action_can_be_executed()
+    {
         $action = app(WriteExist::class);
         $result = $action($this->relation);
 
@@ -24,7 +27,8 @@ class WriteExistTest extends TestCase {
         $this->assertStringContainsString('notifications_exists: boolean', $result);
     }
 
-    public function test_action_can_return_array() {
+    public function test_action_can_return_array()
+    {
         $action = app(WriteExist::class);
         $result = $action($this->relation, jsonOutput: true);
 
@@ -35,20 +39,24 @@ class WriteExistTest extends TestCase {
         ], $result);
     }
 
-    public function test_action_can_be_indented() {
+    public function test_action_can_be_indented()
+    {
         $action = app(WriteExist::class);
         $result = $action($this->relation, indent: 'ASDF');
 
         $this->assertStringContainsString('ASDF  notifications_exists: boolean', $result);
     }
 
-    public function test_action_can_return_optional_exists() {
+    public function test_action_can_return_optional_exists()
+    {
         $action = app(WriteExist::class);
         $result = $action($this->relation, optionalExists: true);
 
         $this->assertStringContainsString('notifications_exists?: boolean', $result);
     }
-    public function test_action_can_return_optional_exists_with_pascal_case() {
+
+    public function test_action_can_return_optional_exists_with_pascal_case()
+    {
         config(['modeltyper.case.columns' => 'pascal']);
         $action = app(WriteExist::class);
         $result = $action($this->relation, optionalExists: true);
@@ -56,7 +64,8 @@ class WriteExistTest extends TestCase {
         $this->assertStringContainsString('NotificationsExists?: boolean', $result);
     }
 
-    public function test_action_can_return_optional_exists_with_camel_case() {
+    public function test_action_can_return_optional_exists_with_camel_case()
+    {
         config(['modeltyper.case.columns' => 'camel']);
         $action = app(WriteExist::class);
         $result = $action($this->relation, optionalExists: true);
@@ -64,7 +73,8 @@ class WriteExistTest extends TestCase {
         $this->assertStringContainsString('notificationsExists?: boolean', $result);
     }
 
-    public function test_action_can_return_optional_exists_as_array() {
+    public function test_action_can_return_optional_exists_as_array()
+    {
         $action = app(WriteExist::class);
         $result = $action($this->relation, jsonOutput: true, optionalExists: true);
 
@@ -74,7 +84,8 @@ class WriteExistTest extends TestCase {
         ], $result);
     }
 
-    public function test_action_can_return_optional_exists_as_array_with_pascal_case() {
+    public function test_action_can_return_optional_exists_as_array_with_pascal_case()
+    {
         config(['modeltyper.case.columns' => 'pascal']);
         $action = app(WriteExist::class);
         $result = $action($this->relation, jsonOutput: true, optionalExists: true);
@@ -85,7 +96,8 @@ class WriteExistTest extends TestCase {
         ], $result);
     }
 
-    public function test_action_can_return_optional_exists_as_array_with_camel_case() {
+    public function test_action_can_return_optional_exists_as_array_with_camel_case()
+    {
         config(['modeltyper.case.columns' => 'camel']);
         $action = app(WriteExist::class);
         $result = $action($this->relation, jsonOutput: true, optionalExists: true);
@@ -96,7 +108,8 @@ class WriteExistTest extends TestCase {
         ], $result);
     }
 
-    public function test_action_returns_empty_string_for_non_existable_relation() {
+    public function test_action_returns_empty_string_for_non_existable_relation()
+    {
         $relation = [
             'name' => 'users',
             'type' => 'MorphedByMany',

--- a/test/Tests/Feature/Actions/WriteRelationshipTest.php
+++ b/test/Tests/Feature/Actions/WriteRelationshipTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Actions;
 
+use FumeApp\ModelTyper\Actions\WriteCount;
+use FumeApp\ModelTyper\Actions\WriteExist;
 use FumeApp\ModelTyper\Actions\WriteRelationship;
 use Tests\TestCase;
 
@@ -35,7 +37,10 @@ class WriteRelationshipTest extends TestCase
 
         $this->assertIsArray($result);
 
-        $this->assertEquals(['name' => 'notifications', 'type' => 'DatabaseNotification[]', 'count' => ['name' => 'notifications_count', 'type' => 'number'], 'exists' => ['name' => 'notifications_exists', 'type' => 'boolean']], $result);
+        $this->assertEquals([
+            'name' => 'notifications',
+            'type' => 'DatabaseNotification[]',
+        ], $result);
     }
 
     public function test_action_can_be_indented()
@@ -57,19 +62,11 @@ class WriteRelationshipTest extends TestCase
     public function test_action_can_return_optional_relationships_as_array()
     {
         $action = app(WriteRelationship::class);
-        $result = $action(relation: $this->relation, optionalRelation: true, jsonOutput: true);
+        $result = $action(relation: $this->relation, jsonOutput: true, optionalRelation: true);
 
         $this->assertEquals([
             'name' => 'notifications?',
             'type' => 'DatabaseNotification[]',
-            'count' => [
-                'name' => 'notifications_count',
-                'type' => 'number',
-            ],
-            'exists' => [
-                'name' => 'notifications_exists',
-                'type' => 'boolean',
-            ],
         ], $result);
     }
 
@@ -84,7 +81,7 @@ class WriteRelationshipTest extends TestCase
     // Add newly added count and exists tests
     public function test_action_can_return_count_relationships()
     {
-        $action = app(WriteRelationship::class);
+        $action = app(WriteCount::class);
         $result = $action(relation: $this->relation);
 
         $this->assertStringContainsString('notifications_count: number', $result);
@@ -92,7 +89,7 @@ class WriteRelationshipTest extends TestCase
 
     public function test_action_can_return_exists_relationships()
     {
-        $action = app(WriteRelationship::class);
+        $action = app(WriteExist::class);
         $result = $action(relation: $this->relation);
 
         $this->assertStringContainsString('notifications_exists: boolean', $result);
@@ -100,7 +97,7 @@ class WriteRelationshipTest extends TestCase
 
     public function test_action_can_return_optional_count_relationships()
     {
-        $action = app(WriteRelationship::class);
+        $action = app(WriteCount::class);
         $result = $action(relation: $this->relation, optionalCounts: true);
 
         $this->assertStringContainsString('notifications_count?: number', $result);
@@ -108,37 +105,9 @@ class WriteRelationshipTest extends TestCase
 
     public function test_action_can_return_optional_exists_relationships()
     {
-        $action = app(WriteRelationship::class);
+        $action = app(WriteExist::class);
         $result = $action(relation: $this->relation, optionalExists: true);
 
         $this->assertStringContainsString('notifications_exists?: boolean', $result);
-    }
-
-    public function test_action_can_return_optional_count_and_exists_relationships()
-    {
-        $action = app(WriteRelationship::class);
-        $result = $action(relation: $this->relation, optionalCounts: true, optionalExists: true);
-
-        $this->assertStringContainsString('notifications_count?: number', $result);
-        $this->assertStringContainsString('notifications_exists?: boolean', $result);
-    }
-
-    public function test_action_can_return_optional_count_and_exists_relationships_as_array()
-    {
-        $action = app(WriteRelationship::class);
-        $result = $action(relation: $this->relation, optionalCounts: true, optionalExists: true, jsonOutput: true);
-
-        $this->assertEquals([
-            'name' => 'notifications?',
-            'type' => 'DatabaseNotification[]',
-            'count' => [
-                'name' => 'notifications_count?',
-                'type' => 'number',
-            ],
-            'exists' => [
-                'name' => 'notifications_exists?',
-                'type' => 'boolean',
-            ],
-        ], $result);
     }
 }

--- a/test/Tests/Feature/Actions/WriteRelationshipTest.php
+++ b/test/Tests/Feature/Actions/WriteRelationshipTest.php
@@ -35,7 +35,7 @@ class WriteRelationshipTest extends TestCase
 
         $this->assertIsArray($result);
 
-        $this->assertEquals(['name' => 'notifications', 'type' => 'DatabaseNotification[]', 'count' => ['name' => 'notifications_count', 'type' => 'number', ], 'exists' => ['name' => 'notifications_exists', 'type' => 'boolean']], $result);
+        $this->assertEquals(['name' => 'notifications', 'type' => 'DatabaseNotification[]', 'count' => ['name' => 'notifications_count', 'type' => 'number'], 'exists' => ['name' => 'notifications_exists', 'type' => 'boolean']], $result);
     }
 
     public function test_action_can_be_indented()
@@ -70,7 +70,8 @@ class WriteRelationshipTest extends TestCase
                 'name' => 'notifications_exists',
                 'type' => 'boolean',
             ],
-        ], $result);    }
+        ], $result);
+    }
 
     public function test_action_can_return_plural_relationships()
     {

--- a/test/Tests/Feature/Actions/WriteSumTest.php
+++ b/test/Tests/Feature/Actions/WriteSumTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Actions;
+
+use FumeApp\ModelTyper\Actions\WriteSum;
+use Tests\TestCase;
+
+class WriteSumTest extends TestCase {
+    protected array $sum = [
+        'relation' => 'orders',
+        'column' => 'total',
+    ];
+
+    public function test_action_can_be_resolved_by_application() {
+        $this->assertInstanceOf(WriteSum::class, resolve(WriteSum::class));
+    }
+
+    public function test_action_can_be_executed() {
+        $action = app(WriteSum::class);
+        $result = $action($this->sum);
+
+        $this->assertIsString($result);
+        $this->assertStringContainsString('orders_sum_total: number | null', $result);
+    }
+
+    public function test_action_can_return_array() {
+        $action = app(WriteSum::class);
+        $result = $action($this->sum, jsonOutput: true);
+
+        $this->assertIsArray($result);
+        $this->assertEquals([
+            'name' => 'orders_sum_total',
+            'type' => 'number | null',
+        ], $result);
+    }
+
+    public function test_action_can_be_indented() {
+        $action = app(WriteSum::class);
+        $result = $action($this->sum, indent: 'ASDF');
+
+        $this->assertStringContainsString('ASDF  orders_sum_total: number | null', $result);
+    }
+
+    public function test_action_can_return_optional_sums() {
+        $action = app(WriteSum::class);
+        $result = $action($this->sum, optionalSums: true);
+
+        $this->assertStringContainsString('orders_sum_total?: number | null', $result);
+    }
+
+    public function test_action_can_return_optional_sums_with_pascal_case() {
+        config(['modeltyper.case.columns' => 'pascal']);
+        $action = app(WriteSum::class);
+        $result = $action($this->sum, optionalSums: true);
+
+        $this->assertStringContainsString('OrdersSumTotal?: number | null', $result);
+    }
+
+    public function test_action_can_return_optional_sums_as_array() {
+        $action = app(WriteSum::class);
+        $result = $action($this->sum, jsonOutput: true, optionalSums: true);
+
+        $this->assertIsArray($result);
+        $this->assertEquals([
+            'name' => 'orders_sum_total?',
+            'type' => 'number | null',
+        ], $result);
+    }
+
+    public function test_action_can_return_optional_sums_with_camel_case() {
+        config(['modeltyper.case.columns' => 'camel']);
+        $action = app(WriteSum::class);
+        $result = $action($this->sum, optionalSums: true);
+
+        $this->assertStringContainsString('ordersSumTotal?: number | null', $result);
+    }
+}

--- a/test/Tests/Feature/Actions/WriteSumTest.php
+++ b/test/Tests/Feature/Actions/WriteSumTest.php
@@ -5,17 +5,20 @@ namespace Tests\Feature\Actions;
 use FumeApp\ModelTyper\Actions\WriteSum;
 use Tests\TestCase;
 
-class WriteSumTest extends TestCase {
+class WriteSumTest extends TestCase
+{
     protected array $sum = [
         'relation' => 'orders',
         'column' => 'total',
     ];
 
-    public function test_action_can_be_resolved_by_application() {
+    public function test_action_can_be_resolved_by_application()
+    {
         $this->assertInstanceOf(WriteSum::class, resolve(WriteSum::class));
     }
 
-    public function test_action_can_be_executed() {
+    public function test_action_can_be_executed()
+    {
         $action = app(WriteSum::class);
         $result = $action($this->sum);
 
@@ -23,7 +26,8 @@ class WriteSumTest extends TestCase {
         $this->assertStringContainsString('orders_sum_total: number | null', $result);
     }
 
-    public function test_action_can_return_array() {
+    public function test_action_can_return_array()
+    {
         $action = app(WriteSum::class);
         $result = $action($this->sum, jsonOutput: true);
 
@@ -34,21 +38,24 @@ class WriteSumTest extends TestCase {
         ], $result);
     }
 
-    public function test_action_can_be_indented() {
+    public function test_action_can_be_indented()
+    {
         $action = app(WriteSum::class);
         $result = $action($this->sum, indent: 'ASDF');
 
         $this->assertStringContainsString('ASDF  orders_sum_total: number | null', $result);
     }
 
-    public function test_action_can_return_optional_sums() {
+    public function test_action_can_return_optional_sums()
+    {
         $action = app(WriteSum::class);
         $result = $action($this->sum, optionalSums: true);
 
         $this->assertStringContainsString('orders_sum_total?: number | null', $result);
     }
 
-    public function test_action_can_return_optional_sums_with_pascal_case() {
+    public function test_action_can_return_optional_sums_with_pascal_case()
+    {
         config(['modeltyper.case.columns' => 'pascal']);
         $action = app(WriteSum::class);
         $result = $action($this->sum, optionalSums: true);
@@ -56,7 +63,8 @@ class WriteSumTest extends TestCase {
         $this->assertStringContainsString('OrdersSumTotal?: number | null', $result);
     }
 
-    public function test_action_can_return_optional_sums_as_array() {
+    public function test_action_can_return_optional_sums_as_array()
+    {
         $action = app(WriteSum::class);
         $result = $action($this->sum, jsonOutput: true, optionalSums: true);
 
@@ -67,7 +75,8 @@ class WriteSumTest extends TestCase {
         ], $result);
     }
 
-    public function test_action_can_return_optional_sums_with_camel_case() {
+    public function test_action_can_return_optional_sums_with_camel_case()
+    {
         config(['modeltyper.case.columns' => 'camel']);
         $action = app(WriteSum::class);
         $result = $action($this->sum, optionalSums: true);

--- a/test/input/expectations/complex-model-camel-case.ts
+++ b/test/input/expectations/complex-model-camel-case.ts
@@ -36,6 +36,8 @@ export interface Complex {
   deletedAt: string | null
   // relations
   complexRelationships: ComplexRelationship[]
+  // counts
   complexRelationshipsCount: number
+  // exists
   complexRelationshipsExists: boolean
 }

--- a/test/input/expectations/complex-model-pascal-case.ts
+++ b/test/input/expectations/complex-model-pascal-case.ts
@@ -36,6 +36,8 @@ export interface Complex {
   DeletedAt: string | null
   // relations
   ComplexRelationships: ComplexRelationship[]
+  // counts
   ComplexRelationshipsCount: number
+  // exists
   ComplexRelationshipsExists: boolean
 }

--- a/test/input/expectations/complex-model-with-cast.ts
+++ b/test/input/expectations/complex-model-with-cast.ts
@@ -36,6 +36,8 @@ export interface Complex {
   deleted_at: string | null
   // relations
   complex_relationships: ComplexRelationship[]
+  // counts
   complex_relationships_count: number
+  // exists
   complex_relationships_exists: boolean
 }

--- a/test/input/expectations/complex-model.ts
+++ b/test/input/expectations/complex-model.ts
@@ -36,6 +36,8 @@ export interface Complex {
   deleted_at: string | null
   // relations
   complex_relationships: ComplexRelationship[]
+  // counts
   complex_relationships_count: number
+  // exists
   complex_relationships_exists: boolean
 }

--- a/test/input/expectations/user-api-resource.ts
+++ b/test/input/expectations/user-api-resource.ts
@@ -15,7 +15,9 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  // counts
   notifications_count: number
+  // exists
   notifications_exists: boolean
 }
 export interface UserResult extends api.MetApiResults { data: User }

--- a/test/input/expectations/user-enums.ts
+++ b/test/input/expectations/user-enums.ts
@@ -15,7 +15,9 @@ export interface User {
   role_enum_traditional: RolesEnum
   // relations
   notifications: DatabaseNotification[]
+  // counts
   notifications_count: number
+  // exists
   notifications_exists: boolean
 }
 

--- a/test/input/expectations/user-fillables.ts
+++ b/test/input/expectations/user-fillables.ts
@@ -15,7 +15,9 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  // counts
   notifications_count: number
+  // exists
   notifications_exists: boolean
 }
 export type UserEditable = Pick<User, 'name' | 'email' | 'password' | 'role_traditional' | 'role_new'>

--- a/test/input/expectations/user-global.ts
+++ b/test/input/expectations/user-global.ts
@@ -19,7 +19,9 @@ declare global {
       role_enum_traditional: Roles
       // relations
       notifications: DatabaseNotification[]
+      // counts
       notifications_count: number
+      // exists
       notifications_exists: boolean
     }
 

--- a/test/input/expectations/user-no-hidden.ts
+++ b/test/input/expectations/user-no-hidden.ts
@@ -13,7 +13,9 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  // counts
   notifications_count: number
+  // exists
   notifications_exists: boolean
 }
 

--- a/test/input/expectations/user-no-relations.ts
+++ b/test/input/expectations/user-no-relations.ts
@@ -13,6 +13,10 @@ export interface User {
   role_new: string
   role_enum: Roles
   role_enum_traditional: Roles
+  // counts
+  notifications_count: number
+  // exists
+  notifications_exists: boolean
 }
 
 const Roles = {

--- a/test/input/expectations/user-optional-nullables.ts
+++ b/test/input/expectations/user-optional-nullables.ts
@@ -15,7 +15,9 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  // counts
   notifications_count: number
+  // exists
   notifications_exists: boolean
 }
 

--- a/test/input/expectations/user-optional-relations.ts
+++ b/test/input/expectations/user-optional-relations.ts
@@ -15,7 +15,9 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications?: DatabaseNotification[]
+  // counts
   notifications_count: number
+  // exists
   notifications_exists: boolean
 }
 

--- a/test/input/expectations/user-plurals.ts
+++ b/test/input/expectations/user-plurals.ts
@@ -15,7 +15,9 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotifications
+  // counts
   notifications_count: number
+  // exists
   notifications_exists: boolean
 }
 export type Users = User[]

--- a/test/input/expectations/user-timestamps-date.ts
+++ b/test/input/expectations/user-timestamps-date.ts
@@ -15,7 +15,9 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  // counts
   notifications_count: number
+  // exists
   notifications_exists: boolean
 }
 

--- a/test/input/expectations/user.json
+++ b/test/input/expectations/user.json
@@ -48,6 +48,14 @@
             {
                 "name": "role_enum_traditional",
                 "type": "RolesEnum"
+            },
+            {
+                "name": "notifications_count",
+                "type": "number"
+            },
+            {
+                "name": "notifications_exists",
+                "type": "boolean"
             }
         ]
     },

--- a/test/input/expectations/user.ts
+++ b/test/input/expectations/user.ts
@@ -15,7 +15,9 @@ export interface User {
   role_enum_traditional: Roles
   // relations
   notifications: DatabaseNotification[]
+  // counts
   notifications_count: number
+  // exists
   notifications_exists: boolean
 }
 


### PR DESCRIPTION
Two new configuration options have been added, along with their corresponding CLI flags: `--no-sums` and `--optional-sums`.

These options provide control over the representation of countable and existence-based relations (such as users, flows, and organization invitations) in the generated TypeScript interfaces.

When enabled:

- `--no-sums`: This option omits all fields that contain sums (e.g., `items_sum_quantity`) from the output.
- `--optional-sums`: This option makes all sum fields optional.