### PR TITLE
Support for Custom Mapped Accessor Methods Types using Eloquent Collections Returns

### DIFF
--- a/src/Actions/WriteColumnAttribute.php
+++ b/src/Actions/WriteColumnAttribute.php
@@ -75,7 +75,7 @@ class WriteColumnAttribute
                                     }
                                 } else {
                                     $rt = $accessorMethodReturnType->getName();
-                                    if (is_subclass_of($rt, \Illuminate\Database\Eloquent\Collection::class)) {
+                                    if (is_subclass_of($rt, \Illuminate\Database\Eloquent\Collection::class) && $returnType($rt, $mappings) !== 'unknown') {
                                         $type = $returnType($rt, $mappings);
                                         $enumRef = $this->resolveEnum($rt);
                                     } else {


### PR DESCRIPTION
### Problem
Previously, the `model:typer` only supported accessors returning instances of  `Illuminate\Database\Eloquent\Casts\Attribute` (i.e., `Attribute::make(...)`),. In this flow, the return type of the `get()`closure was used to infer the output type and optionally override it via the `custom_mappings` array in `modeltyper.php`config.

However, accessor methods returning **custom typed values directly** — such as subclasses of `Illuminate\Database\Eloquent\Collection` — **were not supported**. These accessors would result in the raw collection class name being emitted (e.g., `SomeCollection`), with no way to override the inferred type via configuration.

**Example (Previously Unsupported)**

```php
use App\Collections\SomeCollection; //This Collection extends Illuminate\Database\Eloquent\Collection;

class GenericModel extends Model
{
    {...}
    protected function getSomeCollectionAttribute(): SomeCollection
    {
        return SomeCollection::make(...);
    }
}
```

This would previously generate:

```ts
export interface GenericModel {
    someCollection: SomeCollection; //No type defintion for SomeCollection
}
```

Which is not helpful if you actually want:

```ts
someCollection: SomeOtherModelName[];
```

### Solution
This PR extends the logic in `WriteColumnAttribute`  support accessors that return subclasses of `Illuminate\Database\Eloquent\Collection`.

### Key changes:
- If the accessor does not return an `Attribute` instance, the return type is now inspected.
- If the return type is a subclass of `Illuminate\Database\Eloquent\Collection`, we apply the logic for `custom_mappings`.

When using the `modeltyper.php` config now and adding the collection to the array `'custom_mappings'`:

**Example usage with** `custom_mappings`:

```php
    'custom_mappings' => [
        'App\Collections\SomeColletion' => 'SomeOtherModalName[]',
    ],
```

Generates:

```typescript
export interface GenericModel {
    someCollection: SomeOtherModalName[]
```

### Notes
- This change makes it technically possible to override any return type using `custom_mappings`, not just collections. This could be expanded or constrained depending on intended scope.