### PR TITLE
Honour optional flag in $laravelModel->interfaces to support optional relationships

### DIFF
--- a/src/Actions/BuildModelDetails.php
+++ b/src/Actions/BuildModelDetails.php
@@ -50,6 +50,7 @@ class BuildModelDetails
             'name' => $key,
             'type' => $interface['type'] ?? 'unknown',
             'nullable' => $interface['nullable'] ?? false,
+            'optional' => $interface['optional'] ?? false,
             'import' => $interface['import'] ?? null,
             'forceType' => true,
         ]);

--- a/src/Actions/WriteColumnAttribute.php
+++ b/src/Actions/WriteColumnAttribute.php
@@ -21,7 +21,7 @@ class WriteColumnAttribute
      * Get model columns and attributes to the output.
      *
      * @param  ReflectionClass<Model>  $reflectionModel
-     * @param  array{name: string, type?: string|null, increments: bool, nullable: bool, default: mixed, unique: bool, fillable: bool, hidden?: bool, appended: mixed, cast?: string|null, forceType?: bool}  $attribute
+     * @param  array{name: string, type?: string|null, increments: bool, nullable: bool, default: mixed, unique: bool, fillable: bool, hidden?: bool, appended: mixed, cast?: string|null, forceType?: bool, optional?: bool}  $attribute
      * @param  array<string, string>  $mappings
      * @return array{array{name: string, type: string}, ReflectionClass|null}|array{string, ReflectionClass|null}|array{null, null}
      */

--- a/src/Actions/WriteColumnAttribute.php
+++ b/src/Actions/WriteColumnAttribute.php
@@ -160,7 +160,7 @@ class WriteColumnAttribute
             $type .= ' | null';
         }
 
-        if ((isset($attribute['hidden']) && $attribute['hidden']) || ($optionalNullables && $attribute['nullable'])) {
+        if ((isset($attribute['hidden']) && $attribute['hidden']) || ($optionalNullables && $attribute['nullable']) || (isset($attribute['optional']) && $attribute['optional'])) {
             $name = "{$name}?";
         }
 


### PR DESCRIPTION
## Problem

Currently when overriding default behaviour by using the $laravelModel->interfaces property on the model class, the optional property is dropped when attempting to mark a relationship as optional (instead of null).

## Solution

The following code appends the `optional` parameter to the interfaced mapped through in BuildModelDetails.php, and includes a check for it in WriteColumnAttribute.php so that optional relationships can also be emitted as `relationship?:`