### PR TITLE
Follow up to #110: set-only mutators with enum casts

### DIFF
--- a/src/Actions/WriteColumnAttribute.php
+++ b/src/Actions/WriteColumnAttribute.php
@@ -110,7 +110,28 @@ class WriteColumnAttribute
                                             }
                                         }
                                     } else {
-                                        if ($attribute['type'] !== null) {
+                                        // No get callback: reads go through the model's cast,
+                                        // so fall back to it before the database column type
+                                        $cast = $reflectionModel->newInstance()->getCasts()[$attribute['name']] ?? null;
+
+                                        if (! is_null($cast)) {
+                                            if (Str::contains($cast, '\\')) {
+                                                $castReflection = new ReflectionClass($cast);
+
+                                                if ($castReflection->isEnum()) {
+                                                    $type = $this->getClassName($cast);
+                                                    $enumRef = $castReflection;
+                                                }
+                                            } else {
+                                                $cleanStr = Str::of($cast)->before(':')->lower()->toString();
+
+                                                if (isset($mappings[$cleanStr])) {
+                                                    $type = $returnType($cleanStr, $mappings);
+                                                }
+                                            }
+                                        }
+
+                                        if ($type === 'unknown' && $attribute['type'] !== null) {
                                             $type = $returnType($attribute['type'], $mappings);
                                         }
                                     }

--- a/src/Actions/WriteEnumConst.php
+++ b/src/Actions/WriteEnumConst.php
@@ -26,7 +26,7 @@ class WriteEnumConst
         }
 
         $cases = collect($reflection->getConstants())
-            ->filter(fn ($case) => $case instanceof \UnitEnum);
+            ->filter(fn ($case) => $case instanceof \BackedEnum);
 
         if ($cases->isNotEmpty()) {
             if ($useEnums) {

--- a/src/Actions/WriteEnumConst.php
+++ b/src/Actions/WriteEnumConst.php
@@ -25,7 +25,8 @@ class WriteEnumConst
             $comments = array_map(fn ($match) => trim(str_replace('@property', '', $match)), $matches[0]);
         }
 
-        $cases = collect($reflection->getConstants());
+        $cases = collect($reflection->getConstants())
+            ->filter(fn ($case) => $case instanceof \UnitEnum);
 
         if ($cases->isNotEmpty()) {
             if ($useEnums) {

--- a/test/input/expectations/complex-model-camel-case.ts
+++ b/test/input/expectations/complex-model-camel-case.ts
@@ -26,6 +26,7 @@ export interface Complex {
   string: string
   castedUppercaseString: unknown
   stringWithMutatorAndNoAccessor: string
+  enumWithMutatorAndNoAccessor: Roles
   text: string
   time: string
   timestamp: string
@@ -42,3 +43,14 @@ export interface Complex {
   // exists
   complexRelationshipsExists: boolean
 }
+
+const Roles = {
+  /** Can do anything */
+  ADMIN: 'admin',
+  /** Standard readonly */
+  USER: 'user',
+  /** Value that needs string escaping */
+  USERCLASS: 'App\\Models\\User',
+} as const;
+
+export type Roles = typeof Roles[keyof typeof Roles]

--- a/test/input/expectations/complex-model-pascal-case.ts
+++ b/test/input/expectations/complex-model-pascal-case.ts
@@ -26,6 +26,7 @@ export interface Complex {
   String: string
   CastedUppercaseString: unknown
   StringWithMutatorAndNoAccessor: string
+  EnumWithMutatorAndNoAccessor: Roles
   Text: string
   Time: string
   Timestamp: string
@@ -42,3 +43,14 @@ export interface Complex {
   // exists
   ComplexRelationshipsExists: boolean
 }
+
+const Roles = {
+  /** Can do anything */
+  ADMIN: 'admin',
+  /** Standard readonly */
+  USER: 'user',
+  /** Value that needs string escaping */
+  USERCLASS: 'App\\Models\\User',
+} as const;
+
+export type Roles = typeof Roles[keyof typeof Roles]

--- a/test/input/expectations/complex-model-with-cast.ts
+++ b/test/input/expectations/complex-model-with-cast.ts
@@ -26,6 +26,7 @@ export interface Complex {
   string: string
   casted_uppercase_string: string
   string_with_mutator_and_no_accessor: string
+  enum_with_mutator_and_no_accessor: Roles
   text: string
   time: string
   timestamp: string
@@ -42,3 +43,14 @@ export interface Complex {
   // exists
   complex_relationships_exists: boolean
 }
+
+const Roles = {
+  /** Can do anything */
+  ADMIN: 'admin',
+  /** Standard readonly */
+  USER: 'user',
+  /** Value that needs string escaping */
+  USERCLASS: 'App\\Models\\User',
+} as const;
+
+export type Roles = typeof Roles[keyof typeof Roles]

--- a/test/input/expectations/complex-model.ts
+++ b/test/input/expectations/complex-model.ts
@@ -26,6 +26,7 @@ export interface Complex {
   string: string
   casted_uppercase_string: unknown
   string_with_mutator_and_no_accessor: string
+  enum_with_mutator_and_no_accessor: Roles
   text: string
   time: string
   timestamp: string
@@ -42,3 +43,14 @@ export interface Complex {
   // exists
   complex_relationships_exists: boolean
 }
+
+const Roles = {
+  /** Can do anything */
+  ADMIN: 'admin',
+  /** Standard readonly */
+  USER: 'user',
+  /** Value that needs string escaping */
+  USERCLASS: 'App\\Models\\User',
+} as const;
+
+export type Roles = typeof Roles[keyof typeof Roles]

--- a/test/laravel-skeleton/app/Enums/Roles.php
+++ b/test/laravel-skeleton/app/Enums/Roles.php
@@ -15,6 +15,11 @@ enum Roles: string
     case USER = 'user';
     case USERCLASS = User::class;
 
+    public const NON_ADMIN_ROLES = [
+        self::USER,
+        self::USERCLASS,
+    ];
+
     public static function fromValue(string $value): self
     {
         return match ($value) {

--- a/test/laravel-skeleton/app/Models/Complex.php
+++ b/test/laravel-skeleton/app/Models/Complex.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Casts\UpperCast;
+use App\Enums\Roles;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -16,6 +17,7 @@ class Complex extends Model
         'jsonb' => 'json',
         'year' => 'int',
         'casted_uppercase_string' => UpperCast::class,
+        'enum_with_mutator_and_no_accessor' => Roles::class,
         'immutableDateTime' => 'immutable_date',
         'immutableDate' => 'immutable_datetime',
         'immutableCustomDateTime' => 'immutable_custom_datetime',
@@ -30,6 +32,13 @@ class Complex extends Model
     {
         return Attribute::make(
             set: fn (string $value): string => strtolower($value),
+        );
+    }
+
+    protected function enumWithMutatorAndNoAccessor(): Attribute
+    {
+        return Attribute::make(
+            set: fn (Roles|string $value): string => $value instanceof Roles ? $value->value : $value,
         );
     }
 }

--- a/test/laravel-skeleton/app/Models/Complex.php
+++ b/test/laravel-skeleton/app/Models/Complex.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Casts\UpperCast;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 

--- a/test/laravel-skeleton/database/migrations/0001_01_01_000003_create_complex_model_table.php
+++ b/test/laravel-skeleton/database/migrations/0001_01_01_000003_create_complex_model_table.php
@@ -38,6 +38,7 @@ return new class extends Migration
             $table->string('string');
             $table->string('casted_uppercase_string');
             $table->string('string_with_mutator_and_no_accessor');
+            $table->string('enum_with_mutator_and_no_accessor');
             $table->text('text');
             $table->time('time');
             $table->timestamp('timestamp');


### PR DESCRIPTION
Hi, this is a follow up to my previous PR (#110) with two additional fixes I found while applying the change in production.

After merging #110, models with a set-only Attribute mutator and an enum cast on the same column still generated the database column type (string) rather than the enum type. The cast-based type resolution was being skipped entirely because ModelInspector::getCastType() returns the 'attribute' marker whenever an Attribute method exists, so the enum class name never reached WriteColumnAttribute, and the #110 fallback only looked at $attribute['type'] (the DB column type), not the model's $casts.

While testing I also discovered the fixture I added in #110 (stringWithMutatorAndNoAccessor) never actually exercised the new branch: Illuminate\Database\Eloquent\Casts\Attribute wasn't imported in Complex, so the return type resolved to the non-existent App\Models\Attribute, hasAttributeMutator() returned false, and the test silently passed while going through the wrong path. That's fixed here too.

## Problems

1. A set-only Attribute mutator on a column with an enum cast generates the raw column type (string) instead of the enum type, because the 'attribute' marker from ModelInspector causes the actual cast to be ignored.
2. WriteEnumConst iterates ReflectionClass::getConstants(), which includes plain const declarations alongside enum cases. This caused a crash ("Attempt to read property 'name' on array") on any enum that also defines non-case constants (e.g. a const array of cases, common in one codebase I work on).
3. The Complex test fixture was missing the Attribute import, making the #110 test a no-op.

## Proposal

When no get closure is found, resolve the model's $casts before falling back to the column type. Enum class casts map to their generated const type, and scalar casts go through the normal mappings. This in theory mirrors what Eloquent does at runtime: reads on a set-only attribute still go through the model's cast.

For the WriteEnumConst crash, I suggest we filter getConstants() to only enum case instances before iterating.

I look forward to any feedback about this proposed fix and whether it fits with your vision for the package.

## Changes

- `src/Actions/WriteColumnAttribute.php`: when the Attribute has no get closure, consult getCasts() on the model instance first, then resolve enum casts and scalar casts before falling back to the DB column type.
- `src/Actions/WriteEnumConst.php`: filter constants to instanceof \UnitEnum to skip non-case class constants.
- `test/laravel-skeleton/app/Models/Complex.php`: Add missing use Illuminate\Database\Eloquent\Casts\Attribute import, add enumWithMutatorAndNoAccessor (set-only mutator with a Roles::class cast) to cover the main fix.
- `test/laravel-skeleton/database/migrations/…_create_complex_model_table.php`: add the corresponding column to the table
- `test/laravel-skeleton/app/Enums/Roles.php`: add a `NON_ADMIN_ROLES` const array to exercise the WriteEnumConst fix through all existing enum tests.
- `test/input/expectations/complex-model*.ts`: Update the enum_with_mutator_and_no_accessor: Roles property and the Roles const block on all four expectation variants.